### PR TITLE
feat: submit move, skip turn, words_count fix, and yo/e normalization

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -67,6 +67,8 @@ balda/
 │   │       ├── player_state.go
 │   │       ├── create_game.go
 │   │       ├── join_game.go
+│   │       ├── move_game.go
+│   │       ├── skip_game.go
 │   │       └── list_games.go
 │   ├── service/                      # Application service layer
 │   │   └── balda_service.go          # Orchestrates lobby, matchmaking, storage, notifier
@@ -77,7 +79,10 @@ balda/
 │   │   ├── storage.go                # Thin wrapper over *pgxpool.Pool
 │   │   └── config.go
 │   ├── centrifugo/                   # Centrifugo real-time client
-│   │   └── client.go
+│   │   ├── client.go
+│   │   └── events.go                 # Real-time event payload structs
+│   ├── gamecoord/                    # Bridges game FSM events to Centrifugo
+│   │   └── coord.go                  # Notifier implementation (turn_change, game_state, game_over)
 │   ├── flname/                       # Auto-generated player nicknames
 │   │   └── flname.go
 │   └── rnd/                          # RNG utilities
@@ -209,6 +214,8 @@ Key endpoints:
 | GET | `/games` | List active games |
 | POST | `/games` | Create a new waiting game |
 | POST | `/games/{id}/join` | Join a waiting game |
+| POST | `/games/{id}/move` | Submit a move (place letter + word) |
+| POST | `/games/{id}/skip` | Skip the current turn |
 
 ---
 
@@ -260,7 +267,7 @@ Events are published by HTTP handlers (`internal/server/restapi/handlers/`) dire
 **`game_state` payload** (`internal/centrifugo/events.go`):
 ```json
 { "type": "game_state", "game_id": "…", "board": [["","","","",""],…],
-  "current_turn_uid": "…", "players": [{"uid":"…","score":0}],
+  "current_turn_uid": "…", "players": [{"uid":"…","score":0,"words_count":0}],
   "status": "in_progress", "move_number": 0 }
 ```
 Board is a 5×5 string array (empty string = empty cell; initial word is in row 2).

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.ai/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ balda/
 │   ├── server/
 │   │   ├── ogen/           # ogen-generated server code (do not edit)
 │   │   └── restapi/
-│   │       └── handlers/   # HTTP request handlers
+│   │       └── handlers/   # HTTP request handlers (move_game.go, skip_game.go, etc.)
 │   ├── session/            # Redis-backed session management
 │   ├── service/            # Application service layer
 │   ├── storage/            # PostgreSQL access
@@ -53,7 +53,7 @@ balda/
 ├── frontend/               # Svelte 5 frontend
 │   └── src/
 │       ├── App.svelte      # Root: Centrifugo connection + event dispatch
-│       ├── components/     # AuthForm, Lobby, GameScreen, Board, …
+│       ├── components/     # AuthForm, Lobby, GameScreen, Board, Alphabet, …
 │       ├── stores/         # Reactive game state (game.svelte.ts)
 │       ├── lib/            # api.ts, centrifugo.ts
 │       └── types.ts        # TypeScript interfaces
@@ -143,6 +143,8 @@ Swagger UI is available at `/balda/api/v1/docs` when the server is running.
 | GET | `/games` | List all currently active games |
 | POST | `/games` | Create a new waiting game |
 | POST | `/games/{id}/join` | Join an existing waiting game |
+| POST | `/games/{id}/move` | Submit a move (place letter + word) |
+| POST | `/games/{id}/skip` | Skip the current turn |
 
 ### POST /signup
 
@@ -198,6 +200,37 @@ Joins a waiting game. When the second player joins, the game starts immediately.
 }
 ```
 
+### POST /games/{id}/move
+
+Submits a move: places one new letter on the board and specifies the word path.
+
+```json
+// Request
+{
+  "new_letter": { "row": 3, "col": 3, "char": "е" },
+  "word_path": [
+    { "row": 2, "col": 0 },
+    { "row": 2, "col": 1 },
+    { "row": 2, "col": 2 },
+    { "row": 2, "col": 3 },
+    { "row": 3, "col": 3 }
+  ]
+}
+
+// Response
+{
+  "board": [["","","","",""],…],
+  "current_turn_uid": "…",
+  "players": [{"uid":"…","score":5,"words_count":1}],
+  "status": "in_progress",
+  "move_number": 1
+}
+```
+
+### POST /games/{id}/skip
+
+Skips the current turn. Returns `204 No Content` on success.
+
 ---
 
 ## Real-time Events (Centrifugo)
@@ -218,7 +251,7 @@ Full board snapshot — sent after game start and after each move.
 
 ```json
 { "type": "game_state", "game_id": "…", "board": [["","…"]],
-  "current_turn_uid": "…", "players": [{"uid":"…","score":0}],
+  "current_turn_uid": "…", "players": [{"uid":"…","score":0,"words_count":0}],
   "status": "in_progress", "move_number": 0 }
 ```
 
@@ -237,7 +270,7 @@ Possible `reason` values: `game_start`, `move`, `skip`, `timeout`.
 
 ```json
 { "type": "game_over", "game_id": "…", "winner_uid": "…",
-  "players": [{"uid":"…","score":5}] }
+  "players": [{"uid":"…","score":5,"words_count":2}] }
 ```
 
 `winner_uid` is absent on a draw.
@@ -263,7 +296,7 @@ A 5×5 grid. The starting word occupies the center row (row index 2). Coordinate
 - Each player has **60 seconds** per turn.
 - On timeout the turn passes to the other player automatically; no action from either client is needed.
 - After **3 consecutive timeouts**, the player is kicked and the game ends.
-- A player can skip a turn voluntarily.
+- A player can skip a turn voluntarily via `POST /games/{id}/skip`.
 
 ### Word Validation
 
@@ -273,6 +306,9 @@ Submitted words must:
 - Consist of letters traceable on the board (adjacent cells only)
 - Exist in the embedded Russian nouns dictionary
 - Not have been submitted before in this game
+- Not be identical to the initial board word
+
+> **Note:** `е` and `ё` are treated as the same letter for dictionary lookup, word reuse checks, and board display. For example, a word spelled with `ё` will match a dictionary entry with `е`, and vice versa.
 
 ### State Machine
 

--- a/api/openapi/http-api.yaml
+++ b/api/openapi/http-api.yaml
@@ -183,6 +183,99 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /games/{id}/move:
+    post:
+      operationId: moveGame
+      summary: Submit a move
+      description: |
+        Places a new letter on the board and submits a word. If the word is valid,
+        the player's score is updated and the turn passes to the opponent.
+      tags:
+        - Games
+      security:
+        - APIKeyHeader: []
+        - APIKeyQueryParam: []
+      parameters:
+        - $ref: '#/components/parameters/ApiSessionHeader'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the game
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveRequest"
+      responses:
+        "200":
+          description: Move accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MoveResponse"
+        "400":
+          description: Invalid move (bad word placement, word not in dictionary, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          description: Game not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Not the player's turn or game not in progress
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /games/{id}/skip:
+    post:
+      operationId: skipGame
+      summary: Skip turn
+      description: |
+        Ends the current turn without making a move. The turn passes to the opponent.
+      tags:
+        - Games
+      security:
+        - APIKeyHeader: []
+        - APIKeyQueryParam: []
+      parameters:
+        - $ref: '#/components/parameters/ApiSessionHeader'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the game
+      responses:
+        "204":
+          description: Turn skipped successfully
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          description: Game not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Not the player's turn or game not in progress
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /player/state/{uid}:
     get:
       operationId: getPlayerStateUID
@@ -418,6 +511,76 @@ components:
           description: ID of the player whose turn it is first (the game creator)
           type: string
 
+    BoardCell:
+      type: object
+      required:
+        - row
+        - col
+      properties:
+        row:
+          type: integer
+          minimum: 0
+          maximum: 4
+        col:
+          type: integer
+          minimum: 0
+          maximum: 4
+
+    MoveRequest:
+      type: object
+      required:
+        - new_letter
+        - word_path
+      properties:
+        new_letter:
+          type: object
+          required:
+            - row
+            - col
+            - char
+          properties:
+            row:
+              type: integer
+              minimum: 0
+              maximum: 4
+            col:
+              type: integer
+              minimum: 0
+              maximum: 4
+            char:
+              type: string
+              maxLength: 1
+              description: Single Cyrillic letter to place
+        word_path:
+          type: array
+          minItems: 2
+          items:
+            $ref: "#/components/schemas/BoardCell"
+
+    MoveResponse:
+      type: object
+      properties:
+        board:
+          description: Updated 5x5 board state
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+              maxLength: 1
+        current_turn_uid:
+          description: ID of the player whose turn it is now
+          type: string
+          format: uuid
+        players:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlayerScore"
+        status:
+          $ref: "#/components/schemas/GameStatus"
+        move_number:
+          type: integer
+
     PlayerScore:
       type: object
       properties:
@@ -427,6 +590,9 @@ components:
           format: uuid
         score:
           description: Number of points scored in the current game
+          type: integer
+        words_count:
+          description: Number of words submitted by the player
           type: integer
 
     EvGameCreated:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -19,7 +19,9 @@
   $effect(() => {
     if (gameState.phase === 'auth') return;
     const interval = setInterval(() => {
-      ping(gameState.apiKey, gameState.sessionId, ++pingCounter).catch(() => {});
+      ping(gameState.apiKey, gameState.sessionId, ++pingCounter).catch((err) => {
+        console.error('ping failed', err);
+      });
     }, 5000);
     return () => clearInterval(interval);
   });

--- a/frontend/src/components/Alphabet.svelte
+++ b/frontend/src/components/Alphabet.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  interface Props {
+    onSelect: (char: string) => void;
+    onCancel: () => void;
+  }
+
+  let { onSelect, onCancel }: Props = $props();
+
+  const letters = [
+    'А','Б','В','Г','Д','Е','Ж','З','И','Й',
+    'К','Л','М','Н','О','П','Р','С','Т','У',
+    'Ф','Х','Ц','Ч','Ш','Щ','Ъ','Ы','Ь','Э',
+    'Ю','Я'
+  ];
+</script>
+
+<div class="rounded-xl bg-white p-3 shadow">
+  <div class="grid grid-cols-8 gap-2">
+    {#each letters as char}
+      <button
+        type="button"
+        onclick={() => onSelect(char.toLowerCase())}
+        class="aspect-square rounded-lg bg-blue-50 text-lg font-bold text-blue-700 transition hover:bg-blue-100 active:scale-95"
+      >
+        {char}
+      </button>
+    {/each}
+  </div>
+  <button
+    type="button"
+    onclick={onCancel}
+    class="mt-2 w-full rounded-lg bg-stone-100 py-2 text-sm font-semibold text-stone-600 transition hover:bg-stone-200"
+  >
+    Отмена
+  </button>
+</div>

--- a/frontend/src/components/GameScreen.svelte
+++ b/frontend/src/components/GameScreen.svelte
@@ -4,40 +4,86 @@
   import Timer from './Timer.svelte';
   import WordBar from './WordBar.svelte';
   import Icon from './Icon.svelte';
+  import Alphabet from './Alphabet.svelte';
   import { gameState } from '../stores/game.svelte';
+  import * as api from '../lib/api';
 
-  let newLetter = $state('');
+  let showAlphabet = $state(false);
 
   function handleCellClick(row: number, col: number) {
-    if (!gameState.isMyTurn) return;
+    if (!gameState.isMyTurn || gameState.moveLoading) return;
 
     const cell = gameState.board[row][col];
     if (!cell) {
-      // Empty cell - set as new letter placement
+      // Clicking the same empty cell again cancels the selection
+      if (gameState.newLetterCell?.row === row && gameState.newLetterCell?.col === col) {
+        gameState.undoNewLetter();
+        showAlphabet = false;
+        return;
+      }
+      // Empty cell - set as new letter placement and show alphabet
       gameState.setNewLetterCell(row, col);
+      showAlphabet = true;
       return;
     }
 
     gameState.selectCell(row, col);
   }
 
-  function handlePlaceLetter() {
-    const char = newLetter.trim().toLowerCase();
-    if (char.length === 1 && /^[а-яё]$/i.test(char)) {
-      gameState.setLetterAtCell(char);
-      newLetter = '';
+  function handleAlphabetSelect(char: string) {
+    gameState.setLetterAtCell(char);
+    showAlphabet = false;
+  }
+
+  function handleAlphabetCancel() {
+    gameState.undoNewLetter();
+    showAlphabet = false;
+  }
+
+  async function handleSkip() {
+    if (!gameState.isMyTurn || gameState.moveLoading || !gameState.game) return;
+    gameState.setMoveLoading(true);
+    try {
+      await api.skipTurn(gameState.game.id, gameState.apiKey, gameState.sessionId);
+      gameState.clearSelection();
+      gameState.undoNewLetter();
+    } catch (err: any) {
+      alert(err?.message || 'Не удалось пропустить ход');
+    } finally {
+      gameState.setMoveLoading(false);
     }
   }
 
-  function handleSkip() {
-    // TODO: call API to skip turn
-    alert('Пропуск хода (заглушка)');
-  }
+  async function handleSubmit() {
+    if (!gameState.isMyTurn || gameState.moveLoading || !gameState.game) return;
+    if (!gameState.newLetterCell) {
+      alert('Выберите клетку для новой буквы');
+      return;
+    }
+    if (gameState.currentWord.length < 3) {
+      alert('Слово должно состоять минимум из 3 букв');
+      return;
+    }
 
-  function handleSubmit() {
-    // TODO: call API to submit word
-    alert(`Отправлено слово: ${gameState.currentWord} (заглушка)`);
-    gameState.clearSelection();
+    const payload = {
+      new_letter: {
+        row: gameState.newLetterCell.row,
+        col: gameState.newLetterCell.col,
+        char: gameState.board[gameState.newLetterCell.row][gameState.newLetterCell.col],
+      },
+      word_path: gameState.selectedPath.map((p) => ({ row: p.row, col: p.col })),
+    };
+
+    gameState.setMoveLoading(true);
+    try {
+      const resp = await api.submitMove(gameState.game.id, gameState.apiKey, gameState.sessionId, payload);
+      gameState.applyMoveResponse(resp);
+    } catch (err: any) {
+      alert(err?.message || 'Не удалось отправить слово');
+      gameState.undoNewLetter();
+    } finally {
+      gameState.setMoveLoading(false);
+    }
   }
 
   // Timer tick: only count down once both players are in the game
@@ -93,22 +139,9 @@
     onCellClick={handleCellClick}
   />
 
-  <!-- New letter input -->
-  {#if gameState.isMyTurn && gameState.newLetterCell}
-    <div class="flex items-center justify-center gap-2 rounded-xl bg-blue-50 p-3">
-      <span class="text-sm text-stone-600">Новая буква:</span>
-      <input
-        type="text"
-        maxlength="1"
-        bind:value={newLetter}
-        oninput={handlePlaceLetter}
-        class="h-10 w-10 rounded-lg border-2 border-blue-300 text-center text-xl font-bold uppercase outline-none focus:border-blue-500"
-        placeholder="?"
-      />
-      <span class="text-xs text-stone-500">
-        ({gameState.newLetterCell.row + 1}, {gameState.newLetterCell.col + 1})
-      </span>
-    </div>
+  <!-- Alphabet panel -->
+  {#if gameState.isMyTurn && gameState.newLetterCell && showAlphabet}
+    <Alphabet onSelect={handleAlphabetSelect} onCancel={handleAlphabetCancel} />
   {/if}
 
   <!-- Word bar -->
@@ -118,7 +151,7 @@
   <div class="grid grid-cols-2 gap-3">
     <button
       onclick={handleSkip}
-      disabled={!gameState.isMyTurn}
+      disabled={!gameState.isMyTurn || gameState.moveLoading}
       class="flex items-center justify-center gap-2 rounded-xl bg-stone-200 px-4 py-3 font-bold text-stone-700 transition hover:bg-stone-300 disabled:opacity-50"
     >
       <Icon name="skip" size={18} />
@@ -126,7 +159,7 @@
     </button>
     <button
       onclick={handleSubmit}
-      disabled={!gameState.isMyTurn || gameState.currentWord.length < 3}
+      disabled={!gameState.isMyTurn || gameState.moveLoading || gameState.currentWord.length < 3}
       class="flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-3 font-bold text-white transition hover:bg-blue-700 disabled:opacity-50"
     >
       <Icon name="send" size={18} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7,6 +7,8 @@ import type {
   JoinGameResponse,
   ListGamesResponse,
   PlayerState,
+  MoveRequest,
+  MoveResponse,
 } from '../types';
 
 const API_BASE = '/balda/api/v1';
@@ -49,7 +51,10 @@ export function auth(data: AuthRequest, apiKey: string): Promise<AuthResponse> {
 }
 
 export function ping(apiKey: string, sessionId: string, requestId: number): Promise<void> {
-  return apiFetch('/session/ping', { method: 'POST' }, apiKey, sessionId);
+  return apiFetch('/session/ping', {
+    method: 'POST',
+    headers: { 'X-Request-ID': String(requestId) },
+  }, apiKey, sessionId);
 }
 
 export function getPlayerState(uid: string): Promise<PlayerState> {
@@ -66,4 +71,12 @@ export function createGame(apiKey: string, sessionId: string): Promise<CreateGam
 
 export function joinGame(gameId: string, apiKey: string, sessionId: string): Promise<JoinGameResponse> {
   return apiFetch(`/games/${gameId}/join`, { method: 'POST' }, apiKey, sessionId);
+}
+
+export function submitMove(gameId: string, apiKey: string, sessionId: string, payload: MoveRequest): Promise<MoveResponse> {
+  return apiFetch(`/games/${gameId}/move`, { method: 'POST', body: JSON.stringify(payload) }, apiKey, sessionId);
+}
+
+export function skipTurn(gameId: string, apiKey: string, sessionId: string): Promise<void> {
+  return apiFetch(`/games/${gameId}/skip`, { method: 'POST' }, apiKey, sessionId);
 }

--- a/frontend/src/stores/game.svelte.ts
+++ b/frontend/src/stores/game.svelte.ts
@@ -1,4 +1,4 @@
-import type { GameSummary, PlayerState, EvGameState, EvGameOver, EvTurnChange } from '../types';
+import type { GameSummary, PlayerState, EvGameState, EvGameOver, EvTurnChange, MoveResponse } from '../types';
 
 export type GamePhase = 'auth' | 'lobby' | 'waiting' | 'playing' | 'finished';
 
@@ -32,6 +32,7 @@ export function createGameState() {
   let newLetterCell = $state<{ row: number; col: number } | null>(null);
   let currentWord = $state<string>('');
   let turnSecondsLeft = $state<number>(60);
+  let moveLoading = $state<boolean>(false);
 
   // Derived
   const isMyTurn = $derived(currentTurnUid === playerUid);
@@ -93,7 +94,7 @@ export function createGameState() {
         uid: p.uid,
         nickname: existing?.nickname || (p.uid === playerUid ? nickname : 'Соперник'),
         score: p.score,
-        wordsCount: p.score > 0 ? Math.floor(p.score / 4) : 0,
+        wordsCount: p.words_count ?? 0,
       };
     });
     if (ev.status === 'finished') {
@@ -114,7 +115,7 @@ export function createGameState() {
         uid: p.uid,
         nickname: existing?.nickname || (p.uid === playerUid ? nickname : 'Соперник'),
         score: p.score,
-        wordsCount: p.score > 0 ? Math.floor(p.score / 4) : 0,
+        wordsCount: p.words_count ?? 0,
       };
     });
   }
@@ -125,6 +126,28 @@ export function createGameState() {
     selectedPath = [];
     newLetterCell = null;
     currentWord = '';
+  }
+
+  function applyMoveResponse(resp: MoveResponse) {
+    board = resp.board;
+    currentTurnUid = resp.current_turn_uid;
+    moveNumber = resp.move_number;
+    players = resp.players.map((p) => {
+      const existing = players.find((ep) => ep.uid === p.uid);
+      return {
+        uid: p.uid,
+        nickname: existing?.nickname || (p.uid === playerUid ? nickname : 'Соперник'),
+        score: p.score,
+        wordsCount: p.words_count ?? 0,
+      };
+    });
+    if (resp.status === 'finished') {
+      phase = 'finished';
+    }
+    selectedPath = [];
+    newLetterCell = null;
+    currentWord = '';
+    turnSecondsLeft = 60;
   }
 
   function setTurnTimer(seconds: number) {
@@ -171,6 +194,14 @@ export function createGameState() {
     }
   }
 
+  function undoNewLetter() {
+    if (newLetterCell) {
+      board[newLetterCell.row][newLetterCell.col] = '';
+      newLetterCell = null;
+      rebuildWord();
+    }
+  }
+
   function clearSelection() {
     selectedPath = [];
     currentWord = '';
@@ -194,6 +225,7 @@ export function createGameState() {
     get newLetterCell() { return newLetterCell; },
     get currentWord() { return currentWord; },
     get turnSecondsLeft() { return turnSecondsLeft; },
+    get moveLoading() { return moveLoading; },
     get isMyTurn() { return isMyTurn; },
     get myPlayer() { return myPlayer; },
     get opponent() { return opponent; },
@@ -203,6 +235,7 @@ export function createGameState() {
     setWaiting,
     startGame,
     applyGameState,
+    applyMoveResponse,
     applyTurnChange,
     finishGame,
     setTurnTimer,
@@ -210,7 +243,9 @@ export function createGameState() {
     selectCell,
     setNewLetterCell,
     setLetterAtCell,
+    undoNewLetter,
     clearSelection,
+    setMoveLoading(value: boolean) { moveLoading = value; },
   };
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -60,6 +60,7 @@ export interface ListGamesResponse {
 export interface PlayerScore {
   uid: string;
   score: number;
+  words_count: number;
 }
 
 export interface PlayerState {
@@ -108,6 +109,28 @@ export interface EvTurnChange {
   game_id: string;
   current_turn_uid: string;
   reason: 'game_start' | 'move' | 'skip' | 'timeout';
+}
+
+export interface BoardCell {
+  row: number;
+  col: number;
+}
+
+export interface MoveRequest {
+  new_letter: {
+    row: number;
+    col: number;
+    char: string;
+  };
+  word_path: BoardCell[];
+}
+
+export interface MoveResponse {
+  board: string[][];
+  current_turn_uid: string;
+  players: PlayerScore[];
+  status: GameStatus;
+  move_number: number;
 }
 
 export type CentrifugoEvent = EvGameState | EvGameOver | EvGameCreated | EvGameStarted | EvTurnChange;

--- a/internal/centrifugo/events.go
+++ b/internal/centrifugo/events.go
@@ -25,8 +25,9 @@ type EvGameStarted struct {
 
 // PlayerScore holds a player's uid and current score for EvGameState.
 type PlayerScore struct {
-	UID   string `json:"uid"`
-	Score int    `json:"score"`
+	UID        string `json:"uid"`
+	Score      int    `json:"score"`
+	WordsCount int    `json:"words_count"`
 }
 
 // EvGameState carries the full board snapshot sent after game_started and after each move.

--- a/internal/game/dictionary.go
+++ b/internal/game/dictionary.go
@@ -46,10 +46,11 @@ func NewDictionary() (*Dictionary, error) {
 		i := 0
 		for k, v := range words {
 			def := v.(map[string]interface{})
-			dict.Definition[k] = def["definition"].(string)
+			normK := normalizeWord(k)
+			dict.Definition[normK] = def["definition"].(string)
 
-			if utf8.RuneCountInString(k) == 5 {
-				dict.FiveLetters[i] = k
+			if utf8.RuneCountInString(normK) == 5 {
+				dict.FiveLetters[i] = normK
 				i++
 			}
 		}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 )
@@ -17,6 +18,7 @@ var (
 	ErrNewLetterNotInWord  = errors.New("game: new letter must be included in the word")
 	ErrWordAlreadyUsed     = errors.New("game: word already used")
 	ErrWordNotInDictionary = errors.New("game: word not found in dictionary")
+	ErrWordIsInitialWord   = errors.New("game: word is the initial board word")
 )
 
 const (
@@ -67,7 +69,7 @@ type Game struct {
 }
 
 func (g *Game) СheckWordExistence(word string) bool {
-	if _, ok := Dict.Definition[word]; !ok {
+	if _, ok := Dict.Definition[normalizeWord(word)]; !ok {
 		return false
 	}
 	return true
@@ -78,7 +80,15 @@ func MakeWord(word []Letter) string {
 	for _, v := range word {
 		w += v.Char
 	}
-	return w
+	return normalizeWord(w)
+}
+
+// normalizeWord replaces ё/Ё with е/Е so that words differing only by
+// this letter are treated as identical.
+func normalizeWord(word string) string {
+	word = strings.ReplaceAll(word, "ё", "е")
+	word = strings.ReplaceAll(word, "Ё", "Е")
+	return word
 }
 
 // GapsBetweenLetters reports whether there are gaps between consecutive letters
@@ -275,11 +285,17 @@ func (g *Game) SubmitWord(playerID string, newLetter *Letter, word []Letter) err
 			return ErrWordAlreadyUsed
 		}
 	}
+	if wordStr == g.board.InitialWord() {
+		g.mu.Unlock()
+		return ErrWordIsInitialWord
+	}
 	if !g.СheckWordExistence(wordStr) {
 		g.mu.Unlock()
 		return ErrWordNotInDictionary
 	}
-	if err := g.board.PutLetterOnTable(newLetter); err != nil {
+	normalizedLetter := *newLetter
+	normalizedLetter.Char = normalizeWord(normalizedLetter.Char)
+	if err := g.board.PutLetterOnTable(&normalizedLetter); err != nil {
 		g.mu.Unlock()
 		return err
 	}
@@ -325,17 +341,18 @@ func (g *Game) Board() *LettersTable {
 
 // PlayerScore holds a player's UID and current score for external consumers.
 type PlayerScore struct {
-	UID   string
-	Score int
+	UID        string
+	Score      int
+	WordsCount int
 }
 
-// PlayerScores returns a snapshot of each player's score.
+// PlayerScores returns a snapshot of each player's score and word count.
 func (g *Game) PlayerScores() []PlayerScore {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	out := make([]PlayerScore, len(g.players))
 	for i, p := range g.players {
-		out[i] = PlayerScore{UID: p.ID, Score: p.Score}
+		out[i] = PlayerScore{UID: p.ID, Score: p.Score, WordsCount: len(p.Words)}
 	}
 	return out
 }
@@ -410,9 +427,10 @@ func (g *Game) AddWordToCurrentPlayer(word string) {
 }
 
 func (g *Game) IsTakenWord(word string) bool {
+	word = normalizeWord(word)
 	for _, player := range g.players {
 		for _, pword := range player.Words {
-			if pword == word {
+			if normalizeWord(pword) == word {
 				return true
 			}
 		}

--- a/internal/game/game_test/game_test.go
+++ b/internal/game/game_test/game_test.go
@@ -28,6 +28,24 @@ func TestMakeWord_MultipleLetters(t *testing.T) {
 	assert.Equal(t, "кот", game.MakeWord(letters))
 }
 
+func TestMakeWord_NormalizesYoToE(t *testing.T) {
+	letters := []game.Letter{
+		{Char: "е"},
+		{Char: "л"},
+		{Char: "к"},
+		{Char: "а"},
+	}
+	assert.Equal(t, "елка", game.MakeWord(letters))
+
+	lettersYo := []game.Letter{
+		{Char: "ё"},
+		{Char: "л"},
+		{Char: "к"},
+		{Char: "а"},
+	}
+	assert.Equal(t, "елка", game.MakeWord(lettersYo))
+}
+
 // ─── GapsBetweenLetters ─────────────────────────────────────────────────────
 
 func TestGapsBetweenLetters_AlwaysTrue(t *testing.T) {
@@ -49,6 +67,19 @@ func TestCheckWordExistence_WordNotInDictionary(t *testing.T) {
 	g, err := game.NewGame(nil, nil)
 	require.NoError(t, err)
 	assert.False(t, g.СheckWordExistence("zzzzzznotaword"))
+}
+
+func TestCheckWordExistence_YoMatchesE(t *testing.T) {
+	g, err := game.NewGame(nil, nil)
+	require.NoError(t, err)
+
+	// Runtime dictionary insertion (not from JSON) still uses normalized keys
+	// because addTestWord normalizes, but here we test the lookup directly.
+	game.Dict.Definition["елка"] = "test"
+	t.Cleanup(func() { delete(game.Dict.Definition, "елка") })
+
+	assert.True(t, g.СheckWordExistence("ёлка"), "ё should match е in dictionary")
+	assert.True(t, g.СheckWordExistence("елка"), "е should match е in dictionary")
 }
 
 // ─── Game.AddWordToCurrentPlayer ────────────────────────────────────────────
@@ -111,6 +142,17 @@ func TestGame_IsTakenWord_AcrossMultiplePlayers(t *testing.T) {
 	assert.True(t, g.IsTakenWord("кот"))
 	assert.True(t, g.IsTakenWord("дом"))
 	assert.False(t, g.IsTakenWord("лес"))
+}
+
+func TestGame_IsTakenWord_YoMatchesE(t *testing.T) {
+	players := []*game.Player{
+		{ID: "p1", Words: []string{"елка"}},
+	}
+	g, err := game.NewGame(players, nil)
+	require.NoError(t, err)
+
+	assert.True(t, g.IsTakenWord("ёлка"), "stored word with е should match query with ё")
+	assert.True(t, g.IsTakenWord("елка"), "stored word with е should match query with е")
 }
 
 func TestGapsBetweenLetters(t *testing.T) {

--- a/internal/game/table.go
+++ b/internal/game/table.go
@@ -27,6 +27,7 @@ type LettersTable struct {
 
 func NewLettersTable(w string) (*LettersTable, error) {
 	lt := &LettersTable{Table: [5][5]*Letter{}}
+	w = normalizeWord(w)
 	if utf8.RuneCountInString(w) > InitWordLengthMax {
 		return lt, ErrInitWordLength
 	}

--- a/internal/gamecoord/coord.go
+++ b/internal/gamecoord/coord.go
@@ -102,7 +102,7 @@ func (c *Coordinator) publishGameState() {
 
 	players := make([]centrifugo.PlayerScore, len(scores))
 	for i, s := range scores {
-		players[i] = centrifugo.PlayerScore{UID: s.UID, Score: s.Score}
+		players[i] = centrifugo.PlayerScore{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount}
 	}
 
 	ev := centrifugo.EvGameState{
@@ -128,7 +128,7 @@ func (c *Coordinator) publishGameOver(kickedPlayerID string) {
 	winnerUID := ""
 	players := make([]centrifugo.PlayerScore, len(scores))
 	for i, s := range scores {
-		players[i] = centrifugo.PlayerScore{UID: s.UID, Score: s.Score}
+		players[i] = centrifugo.PlayerScore{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount}
 		if s.UID != kickedPlayerID {
 			winnerUID = s.UID
 		}

--- a/internal/server/ogen/oas_client_gen.go
+++ b/internal/server/ogen/oas_client_gen.go
@@ -61,6 +61,13 @@ type Invoker interface {
 	//
 	// GET /games
 	ListGames(ctx context.Context, params ListGamesParams) (ListGamesRes, error)
+	// MoveGame invokes moveGame operation.
+	//
+	// Places a new letter on the board and submits a word. If the word is valid,
+	// the player's score is updated and the turn passes to the opponent.
+	//
+	// POST /games/{id}/move
+	MoveGame(ctx context.Context, request *MoveRequest, params MoveGameParams) (MoveGameRes, error)
 	// Ping invokes ping operation.
 	//
 	// POST not GET — mutates session TTL.
@@ -75,6 +82,12 @@ type Invoker interface {
 	//
 	// POST /signup
 	Signup(ctx context.Context, request *SignupRequest) (SignupRes, error)
+	// SkipGame invokes skipGame operation.
+	//
+	// Ends the current turn without making a move. The turn passes to the opponent.
+	//
+	// POST /games/{id}/skip
+	SkipGame(ctx context.Context, params SkipGameParams) (SkipGameRes, error)
 }
 
 // Client implements OAS client.
@@ -753,6 +766,162 @@ func (c *Client) sendListGames(ctx context.Context, params ListGamesParams) (res
 	return result, nil
 }
 
+// MoveGame invokes moveGame operation.
+//
+// Places a new letter on the board and submits a word. If the word is valid,
+// the player's score is updated and the turn passes to the opponent.
+//
+// POST /games/{id}/move
+func (c *Client) MoveGame(ctx context.Context, request *MoveRequest, params MoveGameParams) (MoveGameRes, error) {
+	res, err := c.sendMoveGame(ctx, request, params)
+	return res, err
+}
+
+func (c *Client) sendMoveGame(ctx context.Context, request *MoveRequest, params MoveGameParams) (res MoveGameRes, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("moveGame"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.URLTemplateKey.String("/games/{id}/move"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, MoveGameOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [3]string
+	pathParts[0] = "/games/"
+	{
+		// Encode "id" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "id",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.UUIDToString(params.ID))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/move"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeMoveGameRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "EncodeHeaderParams"
+	h := uri.NewHeaderEncoder(r.Header)
+	{
+		cfg := uri.HeaderParameterEncodingConfig{
+			Name:    "X-API-Session",
+			Explode: false,
+		}
+		if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+			return e.EncodeValue(conv.StringToString(params.XAPISession))
+		}); err != nil {
+			return res, errors.Wrap(err, "encode header")
+		}
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			stage = "Security:APIKeyHeader"
+			switch err := c.securityAPIKeyHeader(ctx, MoveGameOperation, r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"APIKeyHeader\"")
+			}
+		}
+		{
+			stage = "Security:APIKeyQueryParam"
+			switch err := c.securityAPIKeyQueryParam(ctx, MoveGameOperation, r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 1
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"APIKeyQueryParam\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+				{0b00000010},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeMoveGameResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
 // Ping invokes ping operation.
 //
 // POST not GET — mutates session TTL.
@@ -969,6 +1138,158 @@ func (c *Client) sendSignup(ctx context.Context, request *SignupRequest) (res Si
 
 	stage = "DecodeResponse"
 	result, err := decodeSignupResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// SkipGame invokes skipGame operation.
+//
+// Ends the current turn without making a move. The turn passes to the opponent.
+//
+// POST /games/{id}/skip
+func (c *Client) SkipGame(ctx context.Context, params SkipGameParams) (SkipGameRes, error) {
+	res, err := c.sendSkipGame(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendSkipGame(ctx context.Context, params SkipGameParams) (res SkipGameRes, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("skipGame"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.URLTemplateKey.String("/games/{id}/skip"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, SkipGameOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [3]string
+	pathParts[0] = "/games/"
+	{
+		// Encode "id" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "id",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.UUIDToString(params.ID))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/skip"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	stage = "EncodeHeaderParams"
+	h := uri.NewHeaderEncoder(r.Header)
+	{
+		cfg := uri.HeaderParameterEncodingConfig{
+			Name:    "X-API-Session",
+			Explode: false,
+		}
+		if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+			return e.EncodeValue(conv.StringToString(params.XAPISession))
+		}); err != nil {
+			return res, errors.Wrap(err, "encode header")
+		}
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			stage = "Security:APIKeyHeader"
+			switch err := c.securityAPIKeyHeader(ctx, SkipGameOperation, r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"APIKeyHeader\"")
+			}
+		}
+		{
+			stage = "Security:APIKeyQueryParam"
+			switch err := c.securityAPIKeyQueryParam(ctx, SkipGameOperation, r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 1
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"APIKeyQueryParam\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+				{0b00000010},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeSkipGameResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/internal/server/ogen/oas_handlers_gen.go
+++ b/internal/server/ogen/oas_handlers_gen.go
@@ -1003,6 +1003,231 @@ func (s *Server) handleListGamesRequest(args [0]string, argsEscaped bool, w http
 	}
 }
 
+// handleMoveGameRequest handles moveGame operation.
+//
+// Places a new letter on the board and submits a word. If the word is valid,
+// the player's score is updated and the turn passes to the opponent.
+//
+// POST /games/{id}/move
+func (s *Server) handleMoveGameRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("moveGame"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/games/{id}/move"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), MoveGameOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(codeAttr)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: MoveGameOperation,
+			ID:   "moveGame",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securityAPIKeyHeader(ctx, MoveGameOperation, r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "APIKeyHeader",
+					Err:              err,
+				}
+				defer recordError("Security:APIKeyHeader", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+		{
+			sctx, ok, err := s.securityAPIKeyQueryParam(ctx, MoveGameOperation, r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "APIKeyQueryParam",
+					Err:              err,
+				}
+				defer recordError("Security:APIKeyQueryParam", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 1
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+				{0b00000010},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodeMoveGameParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var rawBody []byte
+	request, rawBody, close, err := s.decodeMoveGameRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response MoveGameRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    MoveGameOperation,
+			OperationSummary: "Submit a move",
+			OperationID:      "moveGame",
+			Body:             request,
+			RawBody:          rawBody,
+			Params: middleware.Parameters{
+				{
+					Name: "X-API-Session",
+					In:   "header",
+				}: params.XAPISession,
+				{
+					Name: "id",
+					In:   "path",
+				}: params.ID,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = *MoveRequest
+			Params   = MoveGameParams
+			Response = MoveGameRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackMoveGameParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.MoveGame(ctx, request, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.MoveGame(ctx, request, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeMoveGameResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handlePingRequest handles ping operation.
 //
 // POST not GET — mutates session TTL.
@@ -1349,6 +1574,215 @@ func (s *Server) handleSignupRequest(args [0]string, argsEscaped bool, w http.Re
 	}
 
 	if err := encodeSignupResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleSkipGameRequest handles skipGame operation.
+//
+// Ends the current turn without making a move. The turn passes to the opponent.
+//
+// POST /games/{id}/skip
+func (s *Server) handleSkipGameRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("skipGame"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/games/{id}/skip"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), SkipGameOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(codeAttr)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: SkipGameOperation,
+			ID:   "skipGame",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securityAPIKeyHeader(ctx, SkipGameOperation, r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "APIKeyHeader",
+					Err:              err,
+				}
+				defer recordError("Security:APIKeyHeader", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+		{
+			sctx, ok, err := s.securityAPIKeyQueryParam(ctx, SkipGameOperation, r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "APIKeyQueryParam",
+					Err:              err,
+				}
+				defer recordError("Security:APIKeyQueryParam", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 1
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+				{0b00000010},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodeSkipGameParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var rawBody []byte
+
+	var response SkipGameRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    SkipGameOperation,
+			OperationSummary: "Skip turn",
+			OperationID:      "skipGame",
+			Body:             nil,
+			RawBody:          rawBody,
+			Params: middleware.Parameters{
+				{
+					Name: "X-API-Session",
+					In:   "header",
+				}: params.XAPISession,
+				{
+					Name: "id",
+					In:   "path",
+				}: params.ID,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = SkipGameParams
+			Response = SkipGameRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackSkipGameParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.SkipGame(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.SkipGame(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeSkipGameResponse(response, w, span); err != nil {
 		defer recordError("EncodeResponse", err)
 		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
 			s.cfg.ErrorHandler(ctx, w, r, err)

--- a/internal/server/ogen/oas_interfaces_gen.go
+++ b/internal/server/ogen/oas_interfaces_gen.go
@@ -21,10 +21,18 @@ type ListGamesRes interface {
 	listGamesRes()
 }
 
+type MoveGameRes interface {
+	moveGameRes()
+}
+
 type PingRes interface {
 	pingRes()
 }
 
 type SignupRes interface {
 	signupRes()
+}
+
+type SkipGameRes interface {
+	skipGameRes()
 }

--- a/internal/server/ogen/oas_json_gen.go
+++ b/internal/server/ogen/oas_json_gen.go
@@ -224,6 +224,119 @@ func (s *AuthResponse) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *BoardCell) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *BoardCell) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("row")
+		e.Int(s.Row)
+	}
+	{
+		e.FieldStart("col")
+		e.Int(s.Col)
+	}
+}
+
+var jsonFieldsNameOfBoardCell = [2]string{
+	0: "row",
+	1: "col",
+}
+
+// Decode decodes BoardCell from json.
+func (s *BoardCell) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode BoardCell to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "row":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Int()
+				s.Row = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"row\"")
+			}
+		case "col":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Col = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"col\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode BoardCell")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfBoardCell) {
+					name = jsonFieldsNameOfBoardCell[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *BoardCell) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *BoardCell) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *CreateGameResponse) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -896,6 +1009,576 @@ func (s *ListGamesResponse) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes MoveGameBadRequest as json.
+func (s *MoveGameBadRequest) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes MoveGameBadRequest from json.
+func (s *MoveGameBadRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode MoveGameBadRequest to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = MoveGameBadRequest(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *MoveGameBadRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *MoveGameBadRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes MoveGameConflict as json.
+func (s *MoveGameConflict) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes MoveGameConflict from json.
+func (s *MoveGameConflict) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode MoveGameConflict to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = MoveGameConflict(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *MoveGameConflict) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *MoveGameConflict) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes MoveGameNotFound as json.
+func (s *MoveGameNotFound) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes MoveGameNotFound from json.
+func (s *MoveGameNotFound) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode MoveGameNotFound to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = MoveGameNotFound(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *MoveGameNotFound) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *MoveGameNotFound) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes MoveGameUnauthorized as json.
+func (s *MoveGameUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes MoveGameUnauthorized from json.
+func (s *MoveGameUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode MoveGameUnauthorized to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = MoveGameUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *MoveGameUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *MoveGameUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *MoveRequest) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *MoveRequest) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("new_letter")
+		s.NewLetter.Encode(e)
+	}
+	{
+		e.FieldStart("word_path")
+		e.ArrStart()
+		for _, elem := range s.WordPath {
+			elem.Encode(e)
+		}
+		e.ArrEnd()
+	}
+}
+
+var jsonFieldsNameOfMoveRequest = [2]string{
+	0: "new_letter",
+	1: "word_path",
+}
+
+// Decode decodes MoveRequest from json.
+func (s *MoveRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode MoveRequest to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "new_letter":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.NewLetter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"new_letter\"")
+			}
+		case "word_path":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				s.WordPath = make([]BoardCell, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem BoardCell
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.WordPath = append(s.WordPath, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"word_path\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode MoveRequest")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfMoveRequest) {
+					name = jsonFieldsNameOfMoveRequest[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *MoveRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *MoveRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *MoveRequestNewLetter) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *MoveRequestNewLetter) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("row")
+		e.Int(s.Row)
+	}
+	{
+		e.FieldStart("col")
+		e.Int(s.Col)
+	}
+	{
+		e.FieldStart("char")
+		e.Str(s.Char)
+	}
+}
+
+var jsonFieldsNameOfMoveRequestNewLetter = [3]string{
+	0: "row",
+	1: "col",
+	2: "char",
+}
+
+// Decode decodes MoveRequestNewLetter from json.
+func (s *MoveRequestNewLetter) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode MoveRequestNewLetter to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "row":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Int()
+				s.Row = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"row\"")
+			}
+		case "col":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Int()
+				s.Col = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"col\"")
+			}
+		case "char":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.Char = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"char\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode MoveRequestNewLetter")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfMoveRequestNewLetter) {
+					name = jsonFieldsNameOfMoveRequestNewLetter[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *MoveRequestNewLetter) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *MoveRequestNewLetter) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *MoveResponse) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *MoveResponse) encodeFields(e *jx.Encoder) {
+	{
+		if s.Board != nil {
+			e.FieldStart("board")
+			e.ArrStart()
+			for _, elem := range s.Board {
+				e.ArrStart()
+				for _, elem := range elem {
+					e.Str(elem)
+				}
+				e.ArrEnd()
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.CurrentTurnUID.Set {
+			e.FieldStart("current_turn_uid")
+			s.CurrentTurnUID.Encode(e)
+		}
+	}
+	{
+		if s.Players != nil {
+			e.FieldStart("players")
+			e.ArrStart()
+			for _, elem := range s.Players {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.Status.Set {
+			e.FieldStart("status")
+			s.Status.Encode(e)
+		}
+	}
+	{
+		if s.MoveNumber.Set {
+			e.FieldStart("move_number")
+			s.MoveNumber.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfMoveResponse = [5]string{
+	0: "board",
+	1: "current_turn_uid",
+	2: "players",
+	3: "status",
+	4: "move_number",
+}
+
+// Decode decodes MoveResponse from json.
+func (s *MoveResponse) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode MoveResponse to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "board":
+			if err := func() error {
+				s.Board = make([][]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem []string
+					elem = make([]string, 0)
+					if err := d.Arr(func(d *jx.Decoder) error {
+						var elemElem string
+						v, err := d.Str()
+						elemElem = string(v)
+						if err != nil {
+							return err
+						}
+						elem = append(elem, elemElem)
+						return nil
+					}); err != nil {
+						return err
+					}
+					s.Board = append(s.Board, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"board\"")
+			}
+		case "current_turn_uid":
+			if err := func() error {
+				s.CurrentTurnUID.Reset()
+				if err := s.CurrentTurnUID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"current_turn_uid\"")
+			}
+		case "players":
+			if err := func() error {
+				s.Players = make([]PlayerScore, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem PlayerScore
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Players = append(s.Players, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"players\"")
+			}
+		case "status":
+			if err := func() error {
+				s.Status.Reset()
+				if err := s.Status.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"status\"")
+			}
+		case "move_number":
+			if err := func() error {
+				s.MoveNumber.Reset()
+				if err := s.MoveNumber.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"move_number\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode MoveResponse")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *MoveResponse) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *MoveResponse) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes GameStatus as json.
 func (o OptGameStatus) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -1262,6 +1945,103 @@ func (s *Player) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *Player) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *PlayerScore) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *PlayerScore) encodeFields(e *jx.Encoder) {
+	{
+		if s.UID.Set {
+			e.FieldStart("uid")
+			s.UID.Encode(e)
+		}
+	}
+	{
+		if s.Score.Set {
+			e.FieldStart("score")
+			s.Score.Encode(e)
+		}
+	}
+	{
+		if s.WordsCount.Set {
+			e.FieldStart("words_count")
+			s.WordsCount.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfPlayerScore = [3]string{
+	0: "uid",
+	1: "score",
+	2: "words_count",
+}
+
+// Decode decodes PlayerScore from json.
+func (s *PlayerScore) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode PlayerScore to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "uid":
+			if err := func() error {
+				s.UID.Reset()
+				if err := s.UID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"uid\"")
+			}
+		case "score":
+			if err := func() error {
+				s.Score.Reset()
+				if err := s.Score.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"score\"")
+			}
+		case "words_count":
+			if err := func() error {
+				s.WordsCount.Reset()
+				if err := s.WordsCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"words_count\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode PlayerScore")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *PlayerScore) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *PlayerScore) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -1654,6 +2434,120 @@ func (s *SignupResponse) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *SignupResponse) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes SkipGameConflict as json.
+func (s *SkipGameConflict) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes SkipGameConflict from json.
+func (s *SkipGameConflict) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode SkipGameConflict to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = SkipGameConflict(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *SkipGameConflict) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *SkipGameConflict) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes SkipGameNotFound as json.
+func (s *SkipGameNotFound) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes SkipGameNotFound from json.
+func (s *SkipGameNotFound) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode SkipGameNotFound to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = SkipGameNotFound(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *SkipGameNotFound) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *SkipGameNotFound) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes SkipGameUnauthorized as json.
+func (s *SkipGameUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes SkipGameUnauthorized from json.
+func (s *SkipGameUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode SkipGameUnauthorized to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = SkipGameUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *SkipGameUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *SkipGameUnauthorized) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/server/ogen/oas_operations_gen.go
+++ b/internal/server/ogen/oas_operations_gen.go
@@ -11,6 +11,8 @@ const (
 	GetPlayerStateUIDOperation OperationName = "GetPlayerStateUID"
 	JoinGameOperation          OperationName = "JoinGame"
 	ListGamesOperation         OperationName = "ListGames"
+	MoveGameOperation          OperationName = "MoveGame"
 	PingOperation              OperationName = "Ping"
 	SignupOperation            OperationName = "Signup"
+	SkipGameOperation          OperationName = "SkipGame"
 )

--- a/internal/server/ogen/oas_parameters_gen.go
+++ b/internal/server/ogen/oas_parameters_gen.go
@@ -300,6 +300,115 @@ func decodeListGamesParams(args [0]string, argsEscaped bool, r *http.Request) (p
 	return params, nil
 }
 
+// MoveGameParams is parameters of moveGame operation.
+type MoveGameParams struct {
+	XAPISession string
+	// ID of the game.
+	ID uuid.UUID
+}
+
+func unpackMoveGameParams(packed middleware.Parameters) (params MoveGameParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "X-API-Session",
+			In:   "header",
+		}
+		params.XAPISession = packed[key].(string)
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "id",
+			In:   "path",
+		}
+		params.ID = packed[key].(uuid.UUID)
+	}
+	return params
+}
+
+func decodeMoveGameParams(args [1]string, argsEscaped bool, r *http.Request) (params MoveGameParams, _ error) {
+	h := uri.NewHeaderDecoder(r.Header)
+	// Decode header: X-API-Session.
+	if err := func() error {
+		cfg := uri.HeaderParameterDecodingConfig{
+			Name:    "X-API-Session",
+			Explode: false,
+		}
+		if err := h.HasParam(cfg); err == nil {
+			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.XAPISession = c
+				return nil
+			}); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "X-API-Session",
+			In:   "header",
+			Err:  err,
+		}
+	}
+	// Decode path: id.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "id",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToUUID(val)
+				if err != nil {
+					return err
+				}
+
+				params.ID = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "id",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
 // PingParams is parameters of ping operation.
 type PingParams struct {
 	XRequestID  int64
@@ -409,6 +518,115 @@ func decodePingParams(args [0]string, argsEscaped bool, r *http.Request) (params
 		return params, &ogenerrors.DecodeParamError{
 			Name: "X-API-Session",
 			In:   "header",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
+// SkipGameParams is parameters of skipGame operation.
+type SkipGameParams struct {
+	XAPISession string
+	// ID of the game.
+	ID uuid.UUID
+}
+
+func unpackSkipGameParams(packed middleware.Parameters) (params SkipGameParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "X-API-Session",
+			In:   "header",
+		}
+		params.XAPISession = packed[key].(string)
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "id",
+			In:   "path",
+		}
+		params.ID = packed[key].(uuid.UUID)
+	}
+	return params
+}
+
+func decodeSkipGameParams(args [1]string, argsEscaped bool, r *http.Request) (params SkipGameParams, _ error) {
+	h := uri.NewHeaderDecoder(r.Header)
+	// Decode header: X-API-Session.
+	if err := func() error {
+		cfg := uri.HeaderParameterDecodingConfig{
+			Name:    "X-API-Session",
+			Explode: false,
+		}
+		if err := h.HasParam(cfg); err == nil {
+			if err := h.DecodeParam(cfg, func(d uri.Decoder) error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.XAPISession = c
+				return nil
+			}); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "X-API-Session",
+			In:   "header",
+			Err:  err,
+		}
+	}
+	// Decode path: id.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "id",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToUUID(val)
+				if err != nil {
+					return err
+				}
+
+				params.ID = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "id",
+			In:   "path",
 			Err:  err,
 		}
 	}

--- a/internal/server/ogen/oas_request_decoders_gen.go
+++ b/internal/server/ogen/oas_request_decoders_gen.go
@@ -85,6 +85,85 @@ func (s *Server) decodeAuthRequest(r *http.Request) (
 	}
 }
 
+func (s *Server) decodeMoveGameRequest(r *http.Request) (
+	req *MoveRequest,
+	rawBody []byte,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = errors.Join(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = errors.Join(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, rawBody, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, rawBody, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		defer func() {
+			_ = r.Body.Close()
+		}()
+		if err != nil {
+			return req, rawBody, close, err
+		}
+
+		// Reset the body to allow for downstream reading.
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
+
+		if len(buf) == 0 {
+			return req, rawBody, close, validate.ErrBodyRequired
+		}
+
+		rawBody = append(rawBody, buf...)
+		d := jx.DecodeBytes(buf)
+
+		var request MoveRequest
+		if err := func() error {
+			if err := request.Decode(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, rawBody, close, err
+		}
+		if err := func() error {
+			if err := request.Validate(); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return req, rawBody, close, errors.Wrap(err, "validate")
+		}
+		return &request, rawBody, close, nil
+	default:
+		return req, rawBody, close, validate.InvalidContentType(ct)
+	}
+}
+
 func (s *Server) decodeSignupRequest(r *http.Request) (
 	req *SignupRequest,
 	rawBody []byte,

--- a/internal/server/ogen/oas_request_encoders_gen.go
+++ b/internal/server/ogen/oas_request_encoders_gen.go
@@ -24,6 +24,20 @@ func encodeAuthRequest(
 	return nil
 }
 
+func encodeMoveGameRequest(
+	req *MoveRequest,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		req.Encode(e)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
 func encodeSignupRequest(
 	req *SignupRequest,
 	r *http.Request,

--- a/internal/server/ogen/oas_response_decoders_gen.go
+++ b/internal/server/ogen/oas_response_decoders_gen.go
@@ -492,6 +492,196 @@ func decodeListGamesResponse(resp *http.Response) (res ListGamesRes, _ error) {
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
+func decodeMoveGameResponse(resp *http.Response) (res MoveGameRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response MoveResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 400:
+		// Code 400.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response MoveGameBadRequest
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response MoveGameUnauthorized
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response MoveGameNotFound
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 409:
+		// Code 409.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response MoveGameConflict
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
 func decodePingResponse(resp *http.Response) (res PingRes, _ error) {
 	switch resp.StatusCode {
 	case 204:
@@ -689,6 +879,120 @@ func decodeSignupResponse(resp *http.Response) (res SignupRes, _ error) {
 			d := jx.DecodeBytes(buf)
 
 			var response ErrorResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
+func decodeSkipGameResponse(resp *http.Response) (res SkipGameRes, _ error) {
+	switch resp.StatusCode {
+	case 204:
+		// Code 204.
+		return &SkipGameNoContent{}, nil
+	case 401:
+		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response SkipGameUnauthorized
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response SkipGameNotFound
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 409:
+		// Code 409.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response SkipGameConflict
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err

--- a/internal/server/ogen/oas_response_encoders_gen.go
+++ b/internal/server/ogen/oas_response_encoders_gen.go
@@ -204,6 +204,78 @@ func encodeListGamesResponse(response ListGamesRes, w http.ResponseWriter, span 
 	}
 }
 
+func encodeMoveGameResponse(response MoveGameRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *MoveResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *MoveGameBadRequest:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *MoveGameUnauthorized:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *MoveGameNotFound:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *MoveGameConflict:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodePingResponse(response PingRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *PingNoContent:
@@ -284,6 +356,58 @@ func encodeSignupResponse(response SignupRes, w http.ResponseWriter, span trace.
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(400)
 		span.SetStatus(codes.Error, http.StatusText(400))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
+func encodeSkipGameResponse(response SkipGameRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *SkipGameNoContent:
+		w.WriteHeader(204)
+		span.SetStatus(codes.Ok, http.StatusText(204))
+
+		return nil
+
+	case *SkipGameUnauthorized:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(401)
+		span.SetStatus(codes.Error, http.StatusText(401))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *SkipGameNotFound:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *SkipGameConflict:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(409)
+		span.SetStatus(codes.Error, http.StatusText(409))
 
 		e := new(jx.Encoder)
 		response.Encode(e)

--- a/internal/server/ogen/oas_router_gen.go
+++ b/internal/server/ogen/oas_router_gen.go
@@ -21,10 +21,16 @@ var (
 	rn8AllowedHeaders = map[string]string{
 		"POST": "X-Api-Key,X-Api-Session",
 	}
-	rn9AllowedHeaders = map[string]string{
-		"POST": "X-Api-Key,X-Api-Session,X-Request-Id",
+	rn10AllowedHeaders = map[string]string{
+		"POST": "Content-Type,X-Api-Key,X-Api-Session",
+	}
+	rn14AllowedHeaders = map[string]string{
+		"POST": "X-Api-Key,X-Api-Session",
 	}
 	rn11AllowedHeaders = map[string]string{
+		"POST": "X-Api-Key,X-Api-Session,X-Request-Id",
+	}
+	rn13AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
 )
@@ -152,31 +158,99 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						break
 					}
 					switch elem[0] {
-					case '/': // Prefix: "/join"
+					case '/': // Prefix: "/"
 
-						if l := len("/join"); len(elem) >= l && elem[0:l] == "/join" {
+						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
 						if len(elem) == 0 {
-							// Leaf node.
-							switch r.Method {
-							case "POST":
-								s.handleJoinGameRequest([1]string{
-									args[0],
-								}, elemIsEscaped, w, r)
-							default:
-								s.notAllowed(w, r, notAllowedParams{
-									allowedMethods: "POST",
-									allowedHeaders: rn8AllowedHeaders,
-									acceptPost:     "",
-									acceptPatch:    "",
-								})
+							break
+						}
+						switch elem[0] {
+						case 'j': // Prefix: "join"
+
+							if l := len("join"); len(elem) >= l && elem[0:l] == "join" {
+								elem = elem[l:]
+							} else {
+								break
 							}
 
-							return
+							if len(elem) == 0 {
+								// Leaf node.
+								switch r.Method {
+								case "POST":
+									s.handleJoinGameRequest([1]string{
+										args[0],
+									}, elemIsEscaped, w, r)
+								default:
+									s.notAllowed(w, r, notAllowedParams{
+										allowedMethods: "POST",
+										allowedHeaders: rn8AllowedHeaders,
+										acceptPost:     "",
+										acceptPatch:    "",
+									})
+								}
+
+								return
+							}
+
+						case 'm': // Prefix: "move"
+
+							if l := len("move"); len(elem) >= l && elem[0:l] == "move" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch r.Method {
+								case "POST":
+									s.handleMoveGameRequest([1]string{
+										args[0],
+									}, elemIsEscaped, w, r)
+								default:
+									s.notAllowed(w, r, notAllowedParams{
+										allowedMethods: "POST",
+										allowedHeaders: rn10AllowedHeaders,
+										acceptPost:     "application/json",
+										acceptPatch:    "",
+									})
+								}
+
+								return
+							}
+
+						case 's': // Prefix: "skip"
+
+							if l := len("skip"); len(elem) >= l && elem[0:l] == "skip" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch r.Method {
+								case "POST":
+									s.handleSkipGameRequest([1]string{
+										args[0],
+									}, elemIsEscaped, w, r)
+								default:
+									s.notAllowed(w, r, notAllowedParams{
+										allowedMethods: "POST",
+										allowedHeaders: rn14AllowedHeaders,
+										acceptPost:     "",
+										acceptPatch:    "",
+									})
+								}
+
+								return
+							}
+
 						}
 
 					}
@@ -247,7 +321,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn9AllowedHeaders,
+								allowedHeaders: rn11AllowedHeaders,
 								acceptPost:     "",
 								acceptPatch:    "",
 							})
@@ -272,7 +346,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn11AllowedHeaders,
+								allowedHeaders: rn13AllowedHeaders,
 								acceptPost:     "application/json",
 								acceptPatch:    "",
 							})
@@ -462,29 +536,93 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						break
 					}
 					switch elem[0] {
-					case '/': // Prefix: "/join"
+					case '/': // Prefix: "/"
 
-						if l := len("/join"); len(elem) >= l && elem[0:l] == "/join" {
+						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
 						if len(elem) == 0 {
-							// Leaf node.
-							switch method {
-							case "POST":
-								r.name = JoinGameOperation
-								r.summary = "Join an existing waiting game"
-								r.operationID = "joinGame"
-								r.operationGroup = ""
-								r.pathPattern = "/games/{id}/join"
-								r.args = args
-								r.count = 1
-								return r, true
-							default:
-								return
+							break
+						}
+						switch elem[0] {
+						case 'j': // Prefix: "join"
+
+							if l := len("join"); len(elem) >= l && elem[0:l] == "join" {
+								elem = elem[l:]
+							} else {
+								break
 							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch method {
+								case "POST":
+									r.name = JoinGameOperation
+									r.summary = "Join an existing waiting game"
+									r.operationID = "joinGame"
+									r.operationGroup = ""
+									r.pathPattern = "/games/{id}/join"
+									r.args = args
+									r.count = 1
+									return r, true
+								default:
+									return
+								}
+							}
+
+						case 'm': // Prefix: "move"
+
+							if l := len("move"); len(elem) >= l && elem[0:l] == "move" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch method {
+								case "POST":
+									r.name = MoveGameOperation
+									r.summary = "Submit a move"
+									r.operationID = "moveGame"
+									r.operationGroup = ""
+									r.pathPattern = "/games/{id}/move"
+									r.args = args
+									r.count = 1
+									return r, true
+								default:
+									return
+								}
+							}
+
+						case 's': // Prefix: "skip"
+
+							if l := len("skip"); len(elem) >= l && elem[0:l] == "skip" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch method {
+								case "POST":
+									r.name = SkipGameOperation
+									r.summary = "Skip turn"
+									r.operationID = "skipGame"
+									r.operationGroup = ""
+									r.pathPattern = "/games/{id}/skip"
+									r.args = args
+									r.count = 1
+									return r, true
+								default:
+									return
+								}
+							}
+
 						}
 
 					}

--- a/internal/server/ogen/oas_schemas_gen.go
+++ b/internal/server/ogen/oas_schemas_gen.go
@@ -126,6 +126,32 @@ func (s *AuthResponse) SetLobbyToken(val OptString) {
 
 func (*AuthResponse) authRes() {}
 
+// Ref: #/components/schemas/BoardCell
+type BoardCell struct {
+	Row int `json:"row"`
+	Col int `json:"col"`
+}
+
+// GetRow returns the value of Row.
+func (s *BoardCell) GetRow() int {
+	return s.Row
+}
+
+// GetCol returns the value of Col.
+func (s *BoardCell) GetCol() int {
+	return s.Col
+}
+
+// SetRow sets the value of Row.
+func (s *BoardCell) SetRow(val int) {
+	s.Row = val
+}
+
+// SetCol sets the value of Col.
+func (s *BoardCell) SetCol(val int) {
+	s.Col = val
+}
+
 // Ref: #/components/schemas/CreateGameResponse
 type CreateGameResponse struct {
 	Game OptGameSummary `json:"game"`
@@ -386,6 +412,148 @@ func (s *ListGamesResponse) SetGames(val []GameSummary) {
 }
 
 func (*ListGamesResponse) listGamesRes() {}
+
+type MoveGameBadRequest ErrorResponse
+
+func (*MoveGameBadRequest) moveGameRes() {}
+
+type MoveGameConflict ErrorResponse
+
+func (*MoveGameConflict) moveGameRes() {}
+
+type MoveGameNotFound ErrorResponse
+
+func (*MoveGameNotFound) moveGameRes() {}
+
+type MoveGameUnauthorized ErrorResponse
+
+func (*MoveGameUnauthorized) moveGameRes() {}
+
+// Ref: #/components/schemas/MoveRequest
+type MoveRequest struct {
+	NewLetter MoveRequestNewLetter `json:"new_letter"`
+	WordPath  []BoardCell          `json:"word_path"`
+}
+
+// GetNewLetter returns the value of NewLetter.
+func (s *MoveRequest) GetNewLetter() MoveRequestNewLetter {
+	return s.NewLetter
+}
+
+// GetWordPath returns the value of WordPath.
+func (s *MoveRequest) GetWordPath() []BoardCell {
+	return s.WordPath
+}
+
+// SetNewLetter sets the value of NewLetter.
+func (s *MoveRequest) SetNewLetter(val MoveRequestNewLetter) {
+	s.NewLetter = val
+}
+
+// SetWordPath sets the value of WordPath.
+func (s *MoveRequest) SetWordPath(val []BoardCell) {
+	s.WordPath = val
+}
+
+type MoveRequestNewLetter struct {
+	Row int `json:"row"`
+	Col int `json:"col"`
+	// Single Cyrillic letter to place.
+	Char string `json:"char"`
+}
+
+// GetRow returns the value of Row.
+func (s *MoveRequestNewLetter) GetRow() int {
+	return s.Row
+}
+
+// GetCol returns the value of Col.
+func (s *MoveRequestNewLetter) GetCol() int {
+	return s.Col
+}
+
+// GetChar returns the value of Char.
+func (s *MoveRequestNewLetter) GetChar() string {
+	return s.Char
+}
+
+// SetRow sets the value of Row.
+func (s *MoveRequestNewLetter) SetRow(val int) {
+	s.Row = val
+}
+
+// SetCol sets the value of Col.
+func (s *MoveRequestNewLetter) SetCol(val int) {
+	s.Col = val
+}
+
+// SetChar sets the value of Char.
+func (s *MoveRequestNewLetter) SetChar(val string) {
+	s.Char = val
+}
+
+// Ref: #/components/schemas/MoveResponse
+type MoveResponse struct {
+	// Updated 5x5 board state.
+	Board [][]string `json:"board"`
+	// ID of the player whose turn it is now.
+	CurrentTurnUID OptUUID       `json:"current_turn_uid"`
+	Players        []PlayerScore `json:"players"`
+	Status         OptGameStatus `json:"status"`
+	MoveNumber     OptInt        `json:"move_number"`
+}
+
+// GetBoard returns the value of Board.
+func (s *MoveResponse) GetBoard() [][]string {
+	return s.Board
+}
+
+// GetCurrentTurnUID returns the value of CurrentTurnUID.
+func (s *MoveResponse) GetCurrentTurnUID() OptUUID {
+	return s.CurrentTurnUID
+}
+
+// GetPlayers returns the value of Players.
+func (s *MoveResponse) GetPlayers() []PlayerScore {
+	return s.Players
+}
+
+// GetStatus returns the value of Status.
+func (s *MoveResponse) GetStatus() OptGameStatus {
+	return s.Status
+}
+
+// GetMoveNumber returns the value of MoveNumber.
+func (s *MoveResponse) GetMoveNumber() OptInt {
+	return s.MoveNumber
+}
+
+// SetBoard sets the value of Board.
+func (s *MoveResponse) SetBoard(val [][]string) {
+	s.Board = val
+}
+
+// SetCurrentTurnUID sets the value of CurrentTurnUID.
+func (s *MoveResponse) SetCurrentTurnUID(val OptUUID) {
+	s.CurrentTurnUID = val
+}
+
+// SetPlayers sets the value of Players.
+func (s *MoveResponse) SetPlayers(val []PlayerScore) {
+	s.Players = val
+}
+
+// SetStatus sets the value of Status.
+func (s *MoveResponse) SetStatus(val OptGameStatus) {
+	s.Status = val
+}
+
+// SetMoveNumber sets the value of MoveNumber.
+func (s *MoveResponse) SetMoveNumber(val OptInt) {
+	s.MoveNumber = val
+}
+
+func (*MoveResponse) moveGameRes() {}
 
 // NewOptGameStatus returns new OptGameStatus with value set to v.
 func NewOptGameStatus(v GameStatus) OptGameStatus {
@@ -801,6 +969,46 @@ func (s *Player) SetKey(val OptString) {
 	s.Key = val
 }
 
+// Ref: #/components/schemas/PlayerScore
+type PlayerScore struct {
+	// Player's ID.
+	UID OptUUID `json:"uid"`
+	// Number of points scored in the current game.
+	Score OptInt `json:"score"`
+	// Number of words submitted by the player.
+	WordsCount OptInt `json:"words_count"`
+}
+
+// GetUID returns the value of UID.
+func (s *PlayerScore) GetUID() OptUUID {
+	return s.UID
+}
+
+// GetScore returns the value of Score.
+func (s *PlayerScore) GetScore() OptInt {
+	return s.Score
+}
+
+// GetWordsCount returns the value of WordsCount.
+func (s *PlayerScore) GetWordsCount() OptInt {
+	return s.WordsCount
+}
+
+// SetUID sets the value of UID.
+func (s *PlayerScore) SetUID(val OptUUID) {
+	s.UID = val
+}
+
+// SetScore sets the value of Score.
+func (s *PlayerScore) SetScore(val OptInt) {
+	s.Score = val
+}
+
+// SetWordsCount sets the value of WordsCount.
+func (s *PlayerScore) SetWordsCount(val OptInt) {
+	s.WordsCount = val
+}
+
 // Ref: #/components/schemas/PlayerState
 type PlayerState struct {
 	// Player's ID in the system.
@@ -971,3 +1179,20 @@ func (s *SignupResponse) SetLobbyToken(val OptString) {
 }
 
 func (*SignupResponse) signupRes() {}
+
+type SkipGameConflict ErrorResponse
+
+func (*SkipGameConflict) skipGameRes() {}
+
+// SkipGameNoContent is response for SkipGame operation.
+type SkipGameNoContent struct{}
+
+func (*SkipGameNoContent) skipGameRes() {}
+
+type SkipGameNotFound ErrorResponse
+
+func (*SkipGameNotFound) skipGameRes() {}
+
+type SkipGameUnauthorized ErrorResponse
+
+func (*SkipGameUnauthorized) skipGameRes() {}

--- a/internal/server/ogen/oas_security_gen.go
+++ b/internal/server/ogen/oas_security_gen.go
@@ -40,7 +40,9 @@ var operationRolesAPIKeyHeader = map[string][]string{
 	CreateGameOperation: []string{},
 	JoinGameOperation:   []string{},
 	ListGamesOperation:  []string{},
+	MoveGameOperation:   []string{},
 	PingOperation:       []string{},
+	SkipGameOperation:   []string{},
 }
 
 // GetRolesForAPIKeyHeader returns the required roles for the given operation.
@@ -70,7 +72,9 @@ var operationRolesAPIKeyQueryParam = map[string][]string{
 	CreateGameOperation: []string{},
 	JoinGameOperation:   []string{},
 	ListGamesOperation:  []string{},
+	MoveGameOperation:   []string{},
 	PingOperation:       []string{},
+	SkipGameOperation:   []string{},
 }
 
 // GetRolesForAPIKeyQueryParam returns the required roles for the given operation.

--- a/internal/server/ogen/oas_server_gen.go
+++ b/internal/server/ogen/oas_server_gen.go
@@ -41,6 +41,13 @@ type Handler interface {
 	//
 	// GET /games
 	ListGames(ctx context.Context, params ListGamesParams) (ListGamesRes, error)
+	// MoveGame implements moveGame operation.
+	//
+	// Places a new letter on the board and submits a word. If the word is valid,
+	// the player's score is updated and the turn passes to the opponent.
+	//
+	// POST /games/{id}/move
+	MoveGame(ctx context.Context, req *MoveRequest, params MoveGameParams) (MoveGameRes, error)
 	// Ping implements ping operation.
 	//
 	// POST not GET — mutates session TTL.
@@ -55,6 +62,12 @@ type Handler interface {
 	//
 	// POST /signup
 	Signup(ctx context.Context, req *SignupRequest) (SignupRes, error)
+	// SkipGame implements skipGame operation.
+	//
+	// Ends the current turn without making a move. The turn passes to the opponent.
+	//
+	// POST /games/{id}/skip
+	SkipGame(ctx context.Context, params SkipGameParams) (SkipGameRes, error)
 }
 
 // Server implements http server based on OpenAPI v3 specification and

--- a/internal/server/ogen/oas_unimplemented_gen.go
+++ b/internal/server/ogen/oas_unimplemented_gen.go
@@ -61,6 +61,16 @@ func (UnimplementedHandler) ListGames(ctx context.Context, params ListGamesParam
 	return r, ht.ErrNotImplemented
 }
 
+// MoveGame implements moveGame operation.
+//
+// Places a new letter on the board and submits a word. If the word is valid,
+// the player's score is updated and the turn passes to the opponent.
+//
+// POST /games/{id}/move
+func (UnimplementedHandler) MoveGame(ctx context.Context, req *MoveRequest, params MoveGameParams) (r MoveGameRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // Ping implements ping operation.
 //
 // POST not GET — mutates session TTL.
@@ -78,5 +88,14 @@ func (UnimplementedHandler) Ping(ctx context.Context, params PingParams) (r Ping
 //
 // POST /signup
 func (UnimplementedHandler) Signup(ctx context.Context, req *SignupRequest) (r SignupRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// SkipGame implements skipGame operation.
+//
+// Ends the current turn without making a move. The turn passes to the opponent.
+//
+// POST /games/{id}/skip
+func (UnimplementedHandler) SkipGame(ctx context.Context, params SkipGameParams) (r SkipGameRes, _ error) {
 	return r, ht.ErrNotImplemented
 }

--- a/internal/server/ogen/oas_validators_gen.go
+++ b/internal/server/ogen/oas_validators_gen.go
@@ -9,6 +9,60 @@ import (
 	"github.com/ogen-go/ogen/validate"
 )
 
+func (s *BoardCell) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := (validate.Int{
+			MinSet:        true,
+			Min:           0,
+			MaxSet:        true,
+			Max:           4,
+			MinExclusive:  false,
+			MaxExclusive:  false,
+			MultipleOfSet: false,
+			MultipleOf:    0,
+			Pattern:       nil,
+		}).Validate(int64(s.Row)); err != nil {
+			return errors.Wrap(err, "int")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "row",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := (validate.Int{
+			MinSet:        true,
+			Min:           0,
+			MaxSet:        true,
+			Max:           4,
+			MinExclusive:  false,
+			MaxExclusive:  false,
+			MultipleOfSet: false,
+			MultipleOf:    0,
+			Pattern:       nil,
+		}).Validate(int64(s.Col)); err != nil {
+			return errors.Wrap(err, "int")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "col",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *CreateGameResponse) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -165,6 +219,226 @@ func (s *ListGamesResponse) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "games",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *MoveRequest) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.NewLetter.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "new_letter",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if s.WordPath == nil {
+			return errors.New("nil is invalid value")
+		}
+		if err := (validate.Array{
+			MinLength:    2,
+			MinLengthSet: true,
+			MaxLength:    0,
+			MaxLengthSet: false,
+		}).ValidateLength(len(s.WordPath)); err != nil {
+			return errors.Wrap(err, "array")
+		}
+		var failures []validate.FieldError
+		for i, elem := range s.WordPath {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "word_path",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *MoveRequestNewLetter) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := (validate.Int{
+			MinSet:        true,
+			Min:           0,
+			MaxSet:        true,
+			Max:           4,
+			MinExclusive:  false,
+			MaxExclusive:  false,
+			MultipleOfSet: false,
+			MultipleOf:    0,
+			Pattern:       nil,
+		}).Validate(int64(s.Row)); err != nil {
+			return errors.Wrap(err, "int")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "row",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := (validate.Int{
+			MinSet:        true,
+			Min:           0,
+			MaxSet:        true,
+			Max:           4,
+			MinExclusive:  false,
+			MaxExclusive:  false,
+			MultipleOfSet: false,
+			MultipleOf:    0,
+			Pattern:       nil,
+		}).Validate(int64(s.Col)); err != nil {
+			return errors.Wrap(err, "int")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "col",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := (validate.String{
+			MinLength:     0,
+			MinLengthSet:  false,
+			MaxLength:     1,
+			MaxLengthSet:  true,
+			Email:         false,
+			Hostname:      false,
+			Regex:         nil,
+			MinNumeric:    0,
+			MinNumericSet: false,
+			MaxNumeric:    0,
+			MaxNumericSet: false,
+		}).Validate(string(s.Char)); err != nil {
+			return errors.Wrap(err, "string")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "char",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *MoveResponse) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Board {
+			if err := func() error {
+				if elem == nil {
+					return errors.New("nil is invalid value")
+				}
+				var failures []validate.FieldError
+				for i, elem := range elem {
+					if err := func() error {
+						if err := (validate.String{
+							MinLength:     0,
+							MinLengthSet:  false,
+							MaxLength:     1,
+							MaxLengthSet:  true,
+							Email:         false,
+							Hostname:      false,
+							Regex:         nil,
+							MinNumeric:    0,
+							MinNumericSet: false,
+							MaxNumeric:    0,
+							MaxNumericSet: false,
+						}).Validate(string(elem)); err != nil {
+							return errors.Wrap(err, "string")
+						}
+						return nil
+					}(); err != nil {
+						failures = append(failures, validate.FieldError{
+							Name:  fmt.Sprintf("[%d]", i),
+							Error: err,
+						})
+					}
+				}
+				if len(failures) > 0 {
+					return &validate.Error{Fields: failures}
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "board",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.Status.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "status",
 			Error: err,
 		})
 	}

--- a/internal/server/restapi/handlers/join_game.go
+++ b/internal/server/restapi/handlers/join_game.go
@@ -102,7 +102,7 @@ func (h *Handlers) JoinGame(ctx context.Context, params baldaapi.JoinGameParams)
 	// Publish the initial board state so clients render the starting word immediately.
 	players := make([]centrifugo.PlayerScore, 0, len(rec.Players))
 	for _, p := range rec.Players {
-		players = append(players, centrifugo.PlayerScore{UID: p.ID, Score: 0})
+		players = append(players, centrifugo.PlayerScore{UID: p.ID, Score: 0, WordsCount: 0})
 	}
 	// The creator (index 0) always moves first.
 	firstPlayerID := ""

--- a/internal/server/restapi/handlers/move_game.go
+++ b/internal/server/restapi/handlers/move_game.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/rustwizard/balda/internal/centrifugo"
+	"github.com/rustwizard/balda/internal/game"
+	"github.com/rustwizard/balda/internal/lobby"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+	"github.com/rustwizard/balda/internal/session"
+)
+
+// MoveGame implements baldaapi.Handler.
+func (h *Handlers) MoveGame(ctx context.Context, req *baldaapi.MoveRequest, params baldaapi.MoveGameParams) (baldaapi.MoveGameRes, error) {
+	uid, err := h.sess.GetUID(params.XAPISession)
+	if err != nil {
+		if errors.Is(err, session.ErrNotFound) {
+			return &baldaapi.MoveGameUnauthorized{
+				Status:  baldaapi.NewOptInt(http.StatusUnauthorized),
+				Message: baldaapi.NewOptString("session not found"),
+				Type:    baldaapi.NewOptString("Unauthorized"),
+			}, nil
+		}
+		slog.Error("move_game: get uid", slog.String("sid", params.XAPISession), slog.Any("error", err))
+		return &baldaapi.MoveGameUnauthorized{
+			Status:  baldaapi.NewOptInt(http.StatusUnauthorized),
+			Message: baldaapi.NewOptString("session unavailable"),
+			Type:    baldaapi.NewOptString("Unauthorized"),
+		}, nil
+	}
+
+	nl := req.GetNewLetter()
+	newLetter := game.Letter{
+		RowID: uint8(nl.GetRow()),
+		ColID: uint8(nl.GetCol()),
+		Char:  nl.GetChar(),
+	}
+
+	wordPath := make([]game.Letter, 0, len(req.GetWordPath()))
+	for _, cell := range req.GetWordPath() {
+		wordPath = append(wordPath, game.Letter{
+			RowID: uint8(cell.GetRow()),
+			ColID: uint8(cell.GetCol()),
+		})
+	}
+
+	rec, moverID, err := h.svc.SubmitMove(ctx, uid, params.ID.String(), newLetter, wordPath)
+	if err != nil {
+		switch {
+		case errors.Is(err, lobby.ErrGameNotFound):
+			return &baldaapi.MoveGameNotFound{
+				Status:  baldaapi.NewOptInt(http.StatusNotFound),
+				Message: baldaapi.NewOptString("game not found"),
+				Type:    baldaapi.NewOptString("NotFound"),
+			}, nil
+		case errors.Is(err, game.ErrNotYourTurn), errors.Is(err, game.ErrWrongState):
+			return &baldaapi.MoveGameConflict{
+				Status:  baldaapi.NewOptInt(http.StatusConflict),
+				Message: baldaapi.NewOptString(err.Error()),
+				Type:    baldaapi.NewOptString("Conflict"),
+			}, nil
+		case errors.Is(err, game.ErrWordHasGaps),
+			errors.Is(err, game.ErrNewLetterNotInWord),
+			errors.Is(err, game.ErrWordAlreadyUsed),
+			errors.Is(err, game.ErrWordIsInitialWord),
+			errors.Is(err, game.ErrWordNotInDictionary),
+			errors.Is(err, game.ErrWrongLetterPlace),
+			errors.Is(err, game.ErrLetterPlaceTaken):
+			return &baldaapi.MoveGameBadRequest{
+				Status:  baldaapi.NewOptInt(http.StatusBadRequest),
+				Message: baldaapi.NewOptString(err.Error()),
+				Type:    baldaapi.NewOptString("BadRequest"),
+			}, nil
+		default:
+			slog.Error("move_game: submit move", slog.Any("error", err))
+			return &baldaapi.MoveGameBadRequest{
+				Status:  baldaapi.NewOptInt(http.StatusInternalServerError),
+				Message: baldaapi.NewOptString("failed to submit move"),
+				Type:    baldaapi.NewOptString("InternalError"),
+			}, nil
+		}
+	}
+
+	// The game's FSM processes the turn advance asynchronously.
+	// Compute the next player deterministically so the response matches the
+	// eventual server state even if the FSM hasn't advanced yet.
+	nextTurnUID := nextPlayerID(moverID, rec.Game.PlayerScores())
+
+	// Publish updated game state to the game channel.
+	gameState := buildGameState(rec, nextTurnUID)
+	if err := h.cf.Publish(ctx, centrifugo.ChannelGame(rec.ID), gameState); err != nil {
+		slog.Error("move_game: publish game state", slog.Any("error", err))
+	}
+
+	nextUID, err := uuid.Parse(nextTurnUID)
+	if err != nil {
+		slog.Error("move_game: parse next turn uid", slog.Any("error", err))
+	}
+
+	return &baldaapi.MoveResponse{
+		Board:          boardToSlice(rec.Game.Board().AsStrings()),
+		CurrentTurnUID: baldaapi.NewOptUUID(nextUID),
+		Players:        playerScoresToAPI(rec.Game.PlayerScores()),
+		Status:         baldaapi.NewOptGameStatus(baldaapi.GameStatusInProgress),
+		MoveNumber:     baldaapi.NewOptInt(rec.Game.MoveNumber()),
+	}, nil
+}
+
+func boardToSlice(board [5][5]string) [][]string {
+	out := make([][]string, len(board))
+	for i, row := range board {
+		r := make([]string, len(row))
+		copy(r, row[:])
+		out[i] = r
+	}
+	return out
+}
+
+func playerScoresToAPI(scores []game.PlayerScore) []baldaapi.PlayerScore {
+	out := make([]baldaapi.PlayerScore, 0, len(scores))
+	for _, ps := range scores {
+		pid, err := uuid.Parse(ps.UID)
+		if err != nil {
+			continue
+		}
+		out = append(out, baldaapi.PlayerScore{
+			UID:        baldaapi.NewOptUUID(pid),
+			Score:      baldaapi.NewOptInt(ps.Score),
+			WordsCount: baldaapi.NewOptInt(ps.WordsCount),
+		})
+	}
+	return out
+}
+
+func nextPlayerID(moverID string, players []game.PlayerScore) string {
+	for i, p := range players {
+		if p.UID == moverID {
+			return players[(i+1)%len(players)].UID
+		}
+	}
+	return ""
+}
+
+func buildGameState(rec *lobby.GameRecord, currentTurnUID string) centrifugo.EvGameState {
+	players := make([]centrifugo.PlayerScore, 0, len(rec.Players))
+	for _, p := range rec.Players {
+		players = append(players, centrifugo.PlayerScore{UID: p.ID, Score: p.Score, WordsCount: len(p.Words)})
+	}
+	if currentTurnUID == "" {
+		currentTurnUID = rec.Game.CurrentPlayerID()
+	}
+	return centrifugo.EvGameState{
+		Type:           "game_state",
+		GameID:         rec.ID,
+		Board:          rec.Game.Board().AsStrings(),
+		CurrentTurnUID: currentTurnUID,
+		Players:        players,
+		Status:         "in_progress",
+		MoveNumber:     rec.Game.MoveNumber(),
+	}
+}

--- a/internal/server/restapi/handlers/skip_game.go
+++ b/internal/server/restapi/handlers/skip_game.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/rustwizard/balda/internal/centrifugo"
+	"github.com/rustwizard/balda/internal/game"
+	"github.com/rustwizard/balda/internal/lobby"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+	"github.com/rustwizard/balda/internal/session"
+)
+
+// SkipGame implements baldaapi.Handler.
+func (h *Handlers) SkipGame(ctx context.Context, params baldaapi.SkipGameParams) (baldaapi.SkipGameRes, error) {
+	uid, err := h.sess.GetUID(params.XAPISession)
+	if err != nil {
+		if errors.Is(err, session.ErrNotFound) {
+			return &baldaapi.SkipGameUnauthorized{
+				Status:  baldaapi.NewOptInt(http.StatusUnauthorized),
+				Message: baldaapi.NewOptString("session not found"),
+				Type:    baldaapi.NewOptString("Unauthorized"),
+			}, nil
+		}
+		slog.Error("skip_game: get uid", slog.String("sid", params.XAPISession), slog.Any("error", err))
+		return &baldaapi.SkipGameUnauthorized{
+			Status:  baldaapi.NewOptInt(http.StatusUnauthorized),
+			Message: baldaapi.NewOptString("session unavailable"),
+			Type:    baldaapi.NewOptString("Unauthorized"),
+		}, nil
+	}
+
+	rec, moverID, err := h.svc.SkipTurn(ctx, uid, params.ID.String())
+	if err != nil {
+		switch {
+		case errors.Is(err, lobby.ErrGameNotFound):
+			return &baldaapi.SkipGameNotFound{
+				Status:  baldaapi.NewOptInt(http.StatusNotFound),
+				Message: baldaapi.NewOptString("game not found"),
+				Type:    baldaapi.NewOptString("NotFound"),
+			}, nil
+		case errors.Is(err, game.ErrNotYourTurn), errors.Is(err, game.ErrWrongState):
+			return &baldaapi.SkipGameConflict{
+				Status:  baldaapi.NewOptInt(http.StatusConflict),
+				Message: baldaapi.NewOptString(err.Error()),
+				Type:    baldaapi.NewOptString("Conflict"),
+			}, nil
+		default:
+			slog.Error("skip_game: skip turn", slog.Any("error", err))
+			return &baldaapi.SkipGameConflict{
+				Status:  baldaapi.NewOptInt(http.StatusInternalServerError),
+				Message: baldaapi.NewOptString("failed to skip turn"),
+				Type:    baldaapi.NewOptString("InternalError"),
+			}, nil
+		}
+	}
+
+	nextTurnUID := nextPlayerID(moverID, rec.Game.PlayerScores())
+	gameState := buildGameState(rec, nextTurnUID)
+	if err := h.cf.Publish(ctx, centrifugo.ChannelGame(rec.ID), gameState); err != nil {
+		slog.Error("skip_game: publish game state", slog.Any("error", err))
+	}
+
+	return &baldaapi.SkipGameNoContent{}, nil
+}

--- a/internal/service/balda_service.go
+++ b/internal/service/balda_service.go
@@ -67,3 +67,81 @@ func (s *Balda) JoinGame(ctx context.Context, uid int64, gameID string) (*lobby.
 	}
 	return s.lby.Join(ctx, gameID, playerID.String(), s.notifier)
 }
+
+func (s *Balda) playerIDByUID(ctx context.Context, uid int64) (string, error) {
+	var playerID uuid.UUID
+	err := s.s.Pool().QueryRow(ctx,
+		`SELECT player_id FROM player_state WHERE user_id = $1`, uid,
+	).Scan(&playerID)
+	if err != nil {
+		return "", fmt.Errorf("fetch player: %w", err)
+	}
+	return playerID.String(), nil
+}
+
+func (s *Balda) isPlayerInGame(rec *lobby.GameRecord, playerID string) bool {
+	for _, p := range rec.Players {
+		if p.ID == playerID {
+			return true
+		}
+	}
+	return false
+}
+
+// SubmitMove validates and applies a player's move.
+// Returns the game record and the player ID who made the move.
+func (s *Balda) SubmitMove(ctx context.Context, uid int64, gameID string, newLetter game.Letter, wordPath []game.Letter) (*lobby.GameRecord, string, error) {
+	playerID, err := s.playerIDByUID(ctx, uid)
+	if err != nil {
+		return nil, "", err
+	}
+
+	rec, err := s.lby.Get(gameID)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if !s.isPlayerInGame(rec, playerID) {
+		return nil, "", fmt.Errorf("player is not in this game")
+	}
+
+	// Resolve characters for the word path from the current board state.
+	board := rec.Game.Board().AsStrings()
+	for i := range wordPath {
+		if wordPath[i].RowID == newLetter.RowID && wordPath[i].ColID == newLetter.ColID {
+			wordPath[i].Char = newLetter.Char
+		} else {
+			wordPath[i].Char = board[wordPath[i].RowID][wordPath[i].ColID]
+		}
+	}
+
+	if err := rec.Game.SubmitWord(playerID, &newLetter, wordPath); err != nil {
+		return nil, "", err
+	}
+
+	return rec, playerID, nil
+}
+
+// SkipTurn ends the current turn without a move.
+// Returns the game record and the player ID who skipped.
+func (s *Balda) SkipTurn(ctx context.Context, uid int64, gameID string) (*lobby.GameRecord, string, error) {
+	playerID, err := s.playerIDByUID(ctx, uid)
+	if err != nil {
+		return nil, "", err
+	}
+
+	rec, err := s.lby.Get(gameID)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if !s.isPlayerInGame(rec, playerID) {
+		return nil, "", fmt.Errorf("player is not in this game")
+	}
+
+	if err := rec.Game.Skip(playerID); err != nil {
+		return nil, "", err
+	}
+
+	return rec, playerID, nil
+}

--- a/tests/move_game_test.go
+++ b/tests/move_game_test.go
@@ -1,0 +1,387 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rustwizard/balda/internal/game"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func findValidMoveForGame(t *testing.T, g *game.Game) (game.Letter, []game.Letter, bool) {
+	t.Helper()
+	board := g.Board().AsStrings()
+
+	for start := 0; start < 5; start++ {
+		for end := start; end < 5; end++ {
+			segment := make([]game.Letter, 0, end-start+1)
+			for c := start; c <= end; c++ {
+				segment = append(segment, game.Letter{RowID: 2, ColID: uint8(c), Char: board[2][c]})
+			}
+
+			type attach struct {
+				nr, nc  int
+				prepend bool
+			}
+			var attachments []attach
+			for _, d := range []int{-1, 1} {
+				nr := 2 + d
+				if nr >= 0 && nr < 5 {
+					attachments = append(attachments, attach{nr: nr, nc: start, prepend: true})
+					attachments = append(attachments, attach{nr: nr, nc: end, prepend: false})
+				}
+			}
+
+			for _, at := range attachments {
+				if board[at.nr][at.nc] != "" {
+					continue
+				}
+				for _, ru := range "абвгдеёжзийклмнопрстуфхцчшщъыьэюя" {
+					char := string(ru)
+					newLetter := game.Letter{RowID: uint8(at.nr), ColID: uint8(at.nc), Char: char}
+					var path []game.Letter
+					if at.prepend {
+						path = append([]game.Letter{newLetter}, segment...)
+					} else {
+						path = append(segment, newLetter)
+					}
+					word := ""
+					for _, l := range path {
+						word += l.Char
+					}
+					if _, ok := game.Dict.Definition[word]; ok {
+						return newLetter, path, true
+					}
+				}
+			}
+		}
+	}
+	return game.Letter{}, nil, false
+}
+
+func TestMoveGameHandler(t *testing.T) {
+	h, lby, cleanup := setupFull(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	creatorRes, err := h.Signup(ctx, &baldaapi.SignupRequest{
+		Firstname: "Creator", Lastname: "User", Email: "move.creator@example.org", Password: "pass",
+	})
+	require.NoError(t, err)
+	creator := creatorRes.(*baldaapi.SignupResponse).User.Value
+
+	joinerRes, err := h.Signup(ctx, &baldaapi.SignupRequest{
+		Firstname: "Joiner", Lastname: "User", Email: "move.joiner@example.org", Password: "pass",
+	})
+	require.NoError(t, err)
+	joiner := joinerRes.(*baldaapi.SignupResponse).User.Value
+
+	createRes, err := h.CreateGame(ctx, baldaapi.CreateGameParams{XAPISession: creator.Sid.Value})
+	require.NoError(t, err)
+	gameID := createRes.(*baldaapi.CreateGameResponse).Game.Value.ID.Value
+
+	_, err = h.JoinGame(ctx, baldaapi.JoinGameParams{XAPISession: joiner.Sid.Value, ID: gameID})
+	require.NoError(t, err)
+
+	t.Run("unknown session returns 401", func(t *testing.T) {
+		res, err := h.MoveGame(ctx, &baldaapi.MoveRequest{
+			NewLetter: baldaapi.MoveRequestNewLetter{Row: 1, Col: 2, Char: "а"},
+			WordPath:  []baldaapi.BoardCell{{Row: 1, Col: 2}, {Row: 2, Col: 2}},
+		}, baldaapi.MoveGameParams{XAPISession: "bad-sid", ID: gameID})
+		require.NoError(t, err)
+		errResp, ok := res.(*baldaapi.MoveGameUnauthorized)
+		require.True(t, ok, "expected *MoveGameUnauthorized, got %T", res)
+		assert.Equal(t, http.StatusUnauthorized, errResp.Status.Value)
+	})
+
+	t.Run("unknown game id returns 404", func(t *testing.T) {
+		res, err := h.MoveGame(ctx, &baldaapi.MoveRequest{
+			NewLetter: baldaapi.MoveRequestNewLetter{Row: 1, Col: 2, Char: "а"},
+			WordPath:  []baldaapi.BoardCell{{Row: 1, Col: 2}, {Row: 2, Col: 2}},
+		}, baldaapi.MoveGameParams{XAPISession: creator.Sid.Value, ID: uuid.New()})
+		require.NoError(t, err)
+		errResp, ok := res.(*baldaapi.MoveGameNotFound)
+		require.True(t, ok, "expected *MoveGameNotFound, got %T", res)
+		assert.Equal(t, http.StatusNotFound, errResp.Status.Value)
+	})
+
+	t.Run("not player's turn returns 409", func(t *testing.T) {
+		// It is creator's turn first; joiner tries to move.
+		res, err := h.MoveGame(ctx, &baldaapi.MoveRequest{
+			NewLetter: baldaapi.MoveRequestNewLetter{Row: 1, Col: 2, Char: "а"},
+			WordPath:  []baldaapi.BoardCell{{Row: 1, Col: 2}, {Row: 2, Col: 2}},
+		}, baldaapi.MoveGameParams{XAPISession: joiner.Sid.Value, ID: gameID})
+		require.NoError(t, err)
+		errResp, ok := res.(*baldaapi.MoveGameConflict)
+		require.True(t, ok, "expected *MoveGameConflict, got %T", res)
+		assert.Equal(t, http.StatusConflict, errResp.Status.Value)
+	})
+
+	t.Run("invalid word returns 400", func(t *testing.T) {
+		res, err := h.MoveGame(ctx, &baldaapi.MoveRequest{
+			NewLetter: baldaapi.MoveRequestNewLetter{Row: 1, Col: 2, Char: "щ"},
+			WordPath:  []baldaapi.BoardCell{{Row: 1, Col: 2}, {Row: 2, Col: 2}},
+		}, baldaapi.MoveGameParams{XAPISession: creator.Sid.Value, ID: gameID})
+		require.NoError(t, err)
+		errResp, ok := res.(*baldaapi.MoveGameBadRequest)
+		require.True(t, ok, "expected *MoveGameBadRequest, got %T", res)
+		assert.Equal(t, http.StatusBadRequest, errResp.Status.Value)
+	})
+
+	t.Run("new letter not in word path returns 400", func(t *testing.T) {
+		// Place new letter at (1,2) but word path doesn't include it
+		res, err := h.MoveGame(ctx, &baldaapi.MoveRequest{
+			NewLetter: baldaapi.MoveRequestNewLetter{Row: 1, Col: 2, Char: "а"},
+			WordPath:  []baldaapi.BoardCell{{Row: 2, Col: 1}, {Row: 2, Col: 2}},
+		}, baldaapi.MoveGameParams{XAPISession: creator.Sid.Value, ID: gameID})
+		require.NoError(t, err)
+		errResp, ok := res.(*baldaapi.MoveGameBadRequest)
+		require.True(t, ok, "expected *MoveGameBadRequest, got %T", res)
+		assert.Equal(t, http.StatusBadRequest, errResp.Status.Value)
+	})
+
+	t.Run("valid move returns 200 and advances turn", func(t *testing.T) {
+		rec, err := lby.Get(gameID.String())
+		require.NoError(t, err)
+
+		newLetter, wordPath, ok := findValidMoveForGame(t, rec.Game)
+		if !ok {
+			t.Skip("could not find a valid dictionary word for the initial board; skipping happy path")
+		}
+
+		apiPath := make([]baldaapi.BoardCell, len(wordPath))
+		for i, l := range wordPath {
+			apiPath[i] = baldaapi.BoardCell{Row: int(l.RowID), Col: int(l.ColID)}
+		}
+
+		res, err := h.MoveGame(ctx, &baldaapi.MoveRequest{
+			NewLetter: baldaapi.MoveRequestNewLetter{
+				Row: int(newLetter.RowID), Col: int(newLetter.ColID), Char: newLetter.Char,
+			},
+			WordPath: apiPath,
+		}, baldaapi.MoveGameParams{XAPISession: creator.Sid.Value, ID: gameID})
+		require.NoError(t, err)
+
+		okResp, ok := res.(*baldaapi.MoveResponse)
+		require.True(t, ok, "expected *MoveResponse, got %T", res)
+		assert.Equal(t, joiner.UID.Value, okResp.CurrentTurnUID.Value, "turn should advance to joiner")
+		assert.NotEmpty(t, okResp.Board)
+	})
+}
+
+func TestSkipGameHandler(t *testing.T) {
+	h, cleanup := setupHandlers(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	creatorRes, err := h.Signup(ctx, &baldaapi.SignupRequest{
+		Firstname: "Creator", Lastname: "User", Email: "skip.creator@example.org", Password: "pass",
+	})
+	require.NoError(t, err)
+	creator := creatorRes.(*baldaapi.SignupResponse).User.Value
+
+	joinerRes, err := h.Signup(ctx, &baldaapi.SignupRequest{
+		Firstname: "Joiner", Lastname: "User", Email: "skip.joiner@example.org", Password: "pass",
+	})
+	require.NoError(t, err)
+	joiner := joinerRes.(*baldaapi.SignupResponse).User.Value
+
+	createRes, err := h.CreateGame(ctx, baldaapi.CreateGameParams{XAPISession: creator.Sid.Value})
+	require.NoError(t, err)
+	gameID := createRes.(*baldaapi.CreateGameResponse).Game.Value.ID.Value
+
+	_, err = h.JoinGame(ctx, baldaapi.JoinGameParams{XAPISession: joiner.Sid.Value, ID: gameID})
+	require.NoError(t, err)
+
+	t.Run("unknown session returns 401", func(t *testing.T) {
+		res, err := h.SkipGame(ctx, baldaapi.SkipGameParams{XAPISession: "bad-sid", ID: gameID})
+		require.NoError(t, err)
+		errResp, ok := res.(*baldaapi.SkipGameUnauthorized)
+		require.True(t, ok, "expected *SkipGameUnauthorized, got %T", res)
+		assert.Equal(t, http.StatusUnauthorized, errResp.Status.Value)
+	})
+
+	t.Run("wrong turn returns 409", func(t *testing.T) {
+		res, err := h.SkipGame(ctx, baldaapi.SkipGameParams{XAPISession: joiner.Sid.Value, ID: gameID})
+		require.NoError(t, err)
+		errResp, ok := res.(*baldaapi.SkipGameConflict)
+		require.True(t, ok, "expected *SkipGameConflict, got %T", res)
+		assert.Equal(t, http.StatusConflict, errResp.Status.Value)
+	})
+
+	t.Run("valid skip returns 204 and advances turn", func(t *testing.T) {
+		res, err := h.SkipGame(ctx, baldaapi.SkipGameParams{XAPISession: creator.Sid.Value, ID: gameID})
+		require.NoError(t, err)
+		_, ok := res.(*baldaapi.SkipGameNoContent)
+		require.True(t, ok, "expected *SkipGameNoContent, got %T", res)
+	})
+}
+
+func TestMoveGameHTTP(t *testing.T) {
+	srv, email, password, cleanup := setupServer(t)
+	defer cleanup()
+
+	// Auth creator
+	authBody, _ := json.Marshal(map[string]string{"email": email, "password": password})
+	authReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/auth", bytes.NewReader(authBody))
+	authReq.Header.Set("Content-Type", "application/json")
+	authReq.Header.Set("X-API-Key", testAPIToken)
+	resp, err := http.DefaultClient.Do(authReq)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var authData struct {
+		Player struct{ Sid string `json:"sid"` } `json:"player"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&authData))
+	creatorSid := authData.Player.Sid
+
+	joinerSid := postSignup(t, srv, "http.movejoiner@example.org", "pass")
+
+	// Create game
+	createReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/games", http.NoBody)
+	createReq.Header.Set("X-API-Key", testAPIToken)
+	createReq.Header.Set("X-API-Session", creatorSid)
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	defer createResp.Body.Close()
+	require.Equal(t, http.StatusOK, createResp.StatusCode)
+	var createBody struct {
+		Game struct{ ID string `json:"id"` } `json:"game"`
+	}
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&createBody))
+	gameID := createBody.Game.ID
+
+	// Join game
+	joinReq, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/balda/api/v1/games/%s/join", srv.URL, gameID), http.NoBody)
+	joinReq.Header.Set("X-API-Key", testAPIToken)
+	joinReq.Header.Set("X-API-Session", joinerSid)
+	joinResp, err := http.DefaultClient.Do(joinReq)
+	require.NoError(t, err)
+	defer joinResp.Body.Close()
+	require.Equal(t, http.StatusOK, joinResp.StatusCode)
+
+	moveURL := fmt.Sprintf("%s/balda/api/v1/games/%s/move", srv.URL, gameID)
+
+	t.Run("missing api key returns 401", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"new_letter": map[string]any{"row": 1, "col": 2, "char": "а"},
+			"word_path":  []map[string]any{{"row": 1, "col": 2}, {"row": 2, "col": 2}},
+		})
+		req, _ := http.NewRequest(http.MethodPost, moveURL, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-Session", creatorSid)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("unknown session returns 401", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"new_letter": map[string]any{"row": 1, "col": 2, "char": "а"},
+			"word_path":  []map[string]any{{"row": 1, "col": 2}, {"row": 2, "col": 2}},
+		})
+		req, _ := http.NewRequest(http.MethodPost, moveURL, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Session", "bad-sid")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("invalid move returns 400", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"new_letter": map[string]any{"row": 1, "col": 2, "char": "щ"},
+			"word_path":  []map[string]any{{"row": 1, "col": 2}, {"row": 2, "col": 2}},
+		})
+		req, _ := http.NewRequest(http.MethodPost, moveURL, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Session", creatorSid)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("valid move returns 200", func(t *testing.T) {
+		// Simpler: rely on the handler test for the happy path and just verify HTTP wiring here.
+		// The 400 test above already proves the endpoint is wired correctly.
+		t.Skip("happy path covered by handler test; skipping to avoid complex dictionary brute force over HTTP")
+	})
+}
+
+func TestSkipGameHTTP(t *testing.T) {
+	srv, email, password, cleanup := setupServer(t)
+	defer cleanup()
+
+	authBody, _ := json.Marshal(map[string]string{"email": email, "password": password})
+	authReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/auth", bytes.NewReader(authBody))
+	authReq.Header.Set("Content-Type", "application/json")
+	authReq.Header.Set("X-API-Key", testAPIToken)
+	resp, err := http.DefaultClient.Do(authReq)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var authData struct {
+		Player struct{ Sid string `json:"sid"` } `json:"player"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&authData))
+	creatorSid := authData.Player.Sid
+
+	joinerSid := postSignup(t, srv, "http.skipjoiner@example.org", "pass")
+
+	createReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/games", http.NoBody)
+	createReq.Header.Set("X-API-Key", testAPIToken)
+	createReq.Header.Set("X-API-Session", creatorSid)
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	defer createResp.Body.Close()
+	require.Equal(t, http.StatusOK, createResp.StatusCode)
+	var createBody struct {
+		Game struct{ ID string `json:"id"` } `json:"game"`
+	}
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&createBody))
+	gameID := createBody.Game.ID
+
+	joinReq, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/balda/api/v1/games/%s/join", srv.URL, gameID), http.NoBody)
+	joinReq.Header.Set("X-API-Key", testAPIToken)
+	joinReq.Header.Set("X-API-Session", joinerSid)
+	joinResp, err := http.DefaultClient.Do(joinReq)
+	require.NoError(t, err)
+	defer joinResp.Body.Close()
+	require.Equal(t, http.StatusOK, joinResp.StatusCode)
+
+	skipURL := fmt.Sprintf("%s/balda/api/v1/games/%s/skip", srv.URL, gameID)
+
+	t.Run("valid skip returns 204", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, skipURL, http.NoBody)
+		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Session", creatorSid)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("wrong turn returns 409", func(t *testing.T) {
+		// After creator skipped, it's joiner's turn. Creator tries to skip again.
+		req, _ := http.NewRequest(http.MethodPost, skipURL, http.NoBody)
+		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Session", creatorSid)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	})
+}


### PR DESCRIPTION
- Add POST /games/{id}/move and POST /games/{id}/skip endpoints (OpenAPI + ogen + handlers)
- Implement service-layer SubmitMove and SkipTurn with game FSM integration
- Add Alphabet.svelte and wire GameScreen for move submission and turn skipping
- Fix words_count always showing 0 by populating WordsCount in all backend PlayerScore constructions and reading words_count on frontend
- Prevent initial word reuse (ErrWordIsInitialWord)
- Normalize ё/Ё to е/Е for dictionary lookup, word reuse checks, and board placement
- Fix session ping to include X-Request-ID header
- Fix stale current_turn_uid race in HTTP response by computing next turn deterministically
- Add integration tests for move endpoint (tests/move_game_test.go)
- Update README, AGENTS.md, and add .ai/ to .gitignore