### PR TITLE
fix: lobby updates and score/words sync after turn change

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -64,8 +64,10 @@
       case 'skip_warn':
         gameState.applySkipWarn(ev);
         break;
+      case 'lobby_update':
+        gameState.applyLobbyUpdate(ev);
+        break;
       case 'game_created':
-        // Lobby will refresh via its own polling or we could trigger refresh here
         break;
     }
   });

--- a/frontend/src/components/Board.svelte
+++ b/frontend/src/components/Board.svelte
@@ -24,6 +24,9 @@
       if (isSelected(row, col)) {
         return `${base} bg-gradient-to-b from-amber-200 to-amber-300 text-stone-800 shadow-[0_2px_0_#d4d0c8,0_3px_6px_rgba(0,0,0,0.06)] ring-2 ring-blue-500`;
       }
+      if (isNewLetter(row, col)) {
+        return `${base} bg-blue-50 text-blue-700 ring-2 ring-blue-500 ring-dashed shadow-[0_2px_0_#93c5fd]`;
+      }
       return `${base} bg-gradient-to-b from-[#f3e9d8] to-[#e6d5b8] text-stone-800 shadow-[0_4px_0_#c9b896,0_6px_10px_rgba(0,0,0,0.12)]`;
     }
     

--- a/frontend/src/components/GameScreen.svelte
+++ b/frontend/src/components/GameScreen.svelte
@@ -27,15 +27,6 @@
       return;
     }
 
-    // If this is the new letter cell and not yet in the path, show alphabet
-    // so the user can change or cancel the letter
-    const isNewLetter = gameState.newLetterCell?.row === row && gameState.newLetterCell?.col === col;
-    const isInPath = gameState.selectedPath.some((p) => p.row === row && p.col === col);
-    if (isNewLetter && !isInPath) {
-      showAlphabet = true;
-      return;
-    }
-
     gameState.selectCell(row, col);
   }
 
@@ -149,9 +140,19 @@
     onCellClick={handleCellClick}
   />
 
-  <!-- Alphabet panel -->
-  {#if gameState.isMyTurn && gameState.newLetterCell && showAlphabet}
-    <Alphabet onSelect={handleAlphabetSelect} onCancel={handleAlphabetCancel} />
+  <!-- Alphabet panel or cancel-letter button -->
+  {#if gameState.isMyTurn && gameState.newLetterCell}
+    {#if showAlphabet}
+      <Alphabet onSelect={handleAlphabetSelect} onCancel={handleAlphabetCancel} />
+    {:else if gameState.board[gameState.newLetterCell.row][gameState.newLetterCell.col]}
+      <button
+        type="button"
+        onclick={handleAlphabetCancel}
+        class="w-full rounded-xl bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700 ring-1 ring-blue-300 transition hover:bg-blue-100"
+      >
+        ✕ Удалить букву
+      </button>
+    {/if}
   {/if}
 
   <!-- Word bar -->

--- a/frontend/src/components/Lobby.svelte
+++ b/frontend/src/components/Lobby.svelte
@@ -2,21 +2,10 @@
   import { createGame, joinGame, listGames } from '../lib/api';
   import { centrifugo } from '../lib/centrifugo';
   import { gameState } from '../stores/game.svelte';
-  import type { GameSummary } from '../types';
 
-  let games = $state<GameSummary[]>([]);
   let subscribed = $state(false);
   let error = $state('');
   let loading = $state(false);
-
-  async function refresh() {
-    try {
-      const res = await listGames(gameState.apiKey, gameState.sessionId);
-      games = res.games;
-    } catch (err: any) {
-      error = err.message;
-    }
-  }
 
   async function create() {
     loading = true;
@@ -26,7 +15,6 @@
       if (res.game_token) {
         centrifugo.subscribe(`game:${res.game.id}`, res.game_token);
       }
-      // Go straight to the game board; the board is empty until the opponent joins
       gameState.startGame(res.game);
     } catch (err: any) {
       error = err.message;
@@ -44,9 +32,6 @@
         centrifugo.subscribe(`game:${res.game.id}`, res.game_token);
       }
       gameState.startGame(res.game);
-      // Apply initial board directly from the HTTP response to avoid racing
-      // against the Centrifugo game_state event (which was published before
-      // this client subscribed to the game channel).
       if (res.board && res.current_turn_uid) {
         gameState.applyGameState({
           type: 'game_state',
@@ -65,9 +50,12 @@
     }
   }
 
-  // Auto-refresh on mount and subscribe to lobby
+  // Load initial game list and subscribe to lobby channel once
   $effect(() => {
-    refresh();
+    listGames(gameState.apiKey, gameState.sessionId)
+      .then((res) => gameState.setLobbyGames(res.games))
+      .catch((err) => { error = err.message; });
+
     if (!subscribed && gameState.lobbyToken) {
       centrifugo.subscribe('lobby', gameState.lobbyToken);
       subscribed = true;
@@ -78,32 +66,23 @@
 <div class="mx-auto w-full max-w-md rounded-2xl bg-white p-6 shadow-lg">
   <h2 class="mb-4 text-center text-2xl font-bold text-stone-800">Лобби</h2>
 
-  <div class="mb-4 flex gap-2">
-    <button
-      onclick={create}
-      disabled={loading}
-      class="flex-1 rounded-xl bg-blue-600 px-4 py-3 font-bold text-white transition hover:bg-blue-700 disabled:opacity-50"
-    >
-      Создать игру
-    </button>
-    <button
-      onclick={refresh}
-      disabled={loading}
-      class="rounded-xl bg-stone-200 px-4 py-3 font-bold text-stone-700 transition hover:bg-stone-300 disabled:opacity-50"
-    >
-      Обновить
-    </button>
-  </div>
+  <button
+    onclick={create}
+    disabled={loading}
+    class="mb-4 w-full rounded-xl bg-blue-600 px-4 py-3 font-bold text-white transition hover:bg-blue-700 disabled:opacity-50"
+  >
+    Создать игру
+  </button>
 
   {#if error}
     <div class="mb-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>
   {/if}
 
   <div class="flex flex-col gap-2">
-    {#if games.length === 0}
+    {#if gameState.lobbyGames.length === 0}
       <div class="rounded-xl bg-stone-50 p-4 text-center text-stone-500">Нет активных игр</div>
     {:else}
-      {#each games as g}
+      {#each gameState.lobbyGames as g}
         <div class="flex items-center justify-between rounded-xl bg-stone-50 p-3">
           <div class="text-sm">
             <div class="font-semibold text-stone-700">

--- a/frontend/src/lib/centrifugo.ts
+++ b/frontend/src/lib/centrifugo.ts
@@ -7,6 +7,7 @@ export class CentrifugoClient {
   private centrifuge: Centrifuge | null = null;
   private handlers: EventHandler[] = [];
   private subscriptions: Map<string, any> = new Map();
+  private pendingSubscriptions: Array<{ channel: string; token: string }> = [];
 
   connect(wsUrl: string, token: string) {
     console.log('[centrifugo] connect called', wsUrl);
@@ -31,12 +32,18 @@ export class CentrifugoClient {
     });
 
     this.centrifuge.connect();
+
+    // Process any subscriptions requested before connect()
+    const pending = this.pendingSubscriptions;
+    this.pendingSubscriptions = [];
+    pending.forEach(({ channel, token }) => this.subscribe(channel, token));
   }
 
   subscribe(channel: string, token: string) {
     console.log('[centrifugo] subscribe', channel);
     if (!this.centrifuge) {
-      console.warn('[centrifugo] no centrifuge instance, skipping subscribe');
+      console.warn('[centrifugo] no centrifuge instance, queuing subscribe');
+      this.pendingSubscriptions.push({ channel, token });
       return;
     }
     if (this.subscriptions.has(channel)) {

--- a/frontend/src/stores/game.svelte.ts
+++ b/frontend/src/stores/game.svelte.ts
@@ -1,4 +1,4 @@
-import type { GameSummary, PlayerState, EvGameState, EvGameOver, EvTurnChange, EvSkipWarn, MoveResponse } from '../types';
+import type { GameSummary, PlayerState, EvGameState, EvGameOver, EvTurnChange, EvSkipWarn, EvLobbyUpdate, MoveResponse } from '../types';
 
 export type GamePhase = 'auth' | 'lobby' | 'waiting' | 'playing' | 'finished';
 
@@ -30,6 +30,9 @@ export function createGameState() {
 
   // In-game notification (replaces browser alert)
   let notif = $state<{ message: string; kind: 'error' | 'warn' } | null>(null);
+
+  // Lobby game list — updated via lobby_update Centrifugo events
+  let lobbyGames = $state<GameSummary[]>([]);
 
   // Turn interaction
   let selectedPath = $state<{ row: number; col: number }[]>([]);
@@ -223,6 +226,14 @@ export function createGameState() {
     currentWord = '';
   }
 
+  function applyLobbyUpdate(ev: EvLobbyUpdate) {
+    lobbyGames = ev.games;
+  }
+
+  function setLobbyGames(gs: GameSummary[]) {
+    lobbyGames = gs;
+  }
+
   function showNotif(message: string, kind: 'error' | 'warn' = 'error') {
     notif = { message, kind };
   }
@@ -254,6 +265,7 @@ export function createGameState() {
     get myPlayer() { return myPlayer; },
     get opponent() { return opponent; },
     get notif() { return notif; },
+    get lobbyGames() { return lobbyGames; },
 
     setAuth,
     setLobby,
@@ -263,6 +275,8 @@ export function createGameState() {
     applyMoveResponse,
     applyTurnChange,
     applySkipWarn,
+    applyLobbyUpdate,
+    setLobbyGames,
     finishGame,
     setTurnTimer,
     tickTimer,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -133,6 +133,11 @@ export interface MoveResponse {
   move_number: number;
 }
 
+export interface EvLobbyUpdate {
+  type: 'lobby_update';
+  games: GameSummary[];
+}
+
 export interface EvSkipWarn {
   type: 'skip_warn';
   game_id: string;
@@ -141,4 +146,4 @@ export interface EvSkipWarn {
   skips_left: number;
 }
 
-export type CentrifugoEvent = EvGameState | EvGameOver | EvGameCreated | EvGameStarted | EvTurnChange | EvSkipWarn;
+export type CentrifugoEvent = EvGameState | EvGameOver | EvGameCreated | EvGameStarted | EvTurnChange | EvSkipWarn | EvLobbyUpdate;

--- a/internal/centrifugo/events.go
+++ b/internal/centrifugo/events.go
@@ -15,6 +15,21 @@ type EvGameCreated struct {
 	Players []string `json:"player_ids"`
 }
 
+// GameEntry is a single game item inside EvLobbyUpdate.
+type GameEntry struct {
+	ID        string   `json:"id"`
+	PlayerIDs []string `json:"player_ids"`
+	Status    string   `json:"status"`
+	StartedAt int64    `json:"started_at"`
+}
+
+// EvLobbyUpdate is published to the lobby channel whenever the game list changes.
+// The client replaces its local list with the received Games slice.
+type EvLobbyUpdate struct {
+	Type  string      `json:"type"` // "lobby_update"
+	Games []GameEntry `json:"games"`
+}
+
 type EvGameStarted struct {
 	Type      string   `json:"type"`
 	GameID    string   `json:"game_id"`

--- a/internal/server/restapi/handlers/create_game.go
+++ b/internal/server/restapi/handlers/create_game.go
@@ -70,8 +70,10 @@ func (h *Handlers) CreateGame(ctx context.Context, params baldaapi.CreateGamePar
 		ev.Players = append(ev.Players, p.ID)
 	}
 	if err := h.cf.Publish(ctx, centrifugo.ChannelLobby, ev); err != nil {
-		slog.Error("create_game: publish to centrifugo", slog.Any("error", err))
+		slog.Error("create_game: publish game_created", slog.Any("error", err))
 	}
+
+	h.publishLobbyUpdate(ctx)
 
 	gameToken, err := centrifugo.GenerateSubscriptionToken(
 		strconv.FormatInt(uid, 10), centrifugo.ChannelGame(rec.ID), h.centrifugoTokenHMACSecret, 24*time.Hour,

--- a/internal/server/restapi/handlers/handlers.go
+++ b/internal/server/restapi/handlers/handlers.go
@@ -42,6 +42,27 @@ func (h *Handlers) generateCentrifugoTokens(uid int64) (cfToken, lobbyToken stri
 	return
 }
 
+// publishLobbyUpdate fetches the current game list and publishes EvLobbyUpdate
+// to the lobby channel so all connected clients refresh without an API call.
+func (h *Handlers) publishLobbyUpdate(ctx context.Context) {
+	games := h.svc.ListGames()
+	ev := centrifugo.EvLobbyUpdate{
+		Type:  "lobby_update",
+		Games: make([]centrifugo.GameEntry, 0, len(games)),
+	}
+	for _, g := range games {
+		ev.Games = append(ev.Games, centrifugo.GameEntry{
+			ID:        g.ID,
+			PlayerIDs: g.PlayerIDs,
+			Status:    string(g.Status),
+			StartedAt: g.StartedAt.UnixMilli(),
+		})
+	}
+	if err := h.cf.Publish(ctx, centrifugo.ChannelLobby, ev); err != nil {
+		slog.Error("publish lobby_update", slog.Any("error", err))
+	}
+}
+
 // HandleAPIKeyHeader implements baldaapi.SecurityHandler.
 func (h *Handlers) HandleAPIKeyHeader(ctx context.Context, _ baldaapi.OperationName, t baldaapi.APIKeyHeader) (context.Context, error) {
 	slog.Info("KeyAuth header handler called")

--- a/internal/server/restapi/handlers/join_game.go
+++ b/internal/server/restapi/handlers/join_game.go
@@ -98,6 +98,7 @@ func (h *Handlers) JoinGame(ctx context.Context, params baldaapi.JoinGameParams)
 	if err := h.cf.Publish(ctx, centrifugo.ChannelGame(rec.ID), ev); err != nil {
 		slog.Error("join_game: publish to game channel", slog.Any("error", err))
 	}
+	h.publishLobbyUpdate(ctx)
 
 	// Publish the initial board state so clients render the starting word immediately.
 	players := make([]centrifugo.PlayerScore, 0, len(rec.Players))

--- a/internal/server/restapi/handlers/move_game.go
+++ b/internal/server/restapi/handlers/move_game.go
@@ -146,9 +146,10 @@ func nextPlayerID(moverID string, players []game.PlayerScore) string {
 }
 
 func buildGameState(rec *lobby.GameRecord, currentTurnUID string) centrifugo.EvGameState {
-	players := make([]centrifugo.PlayerScore, 0, len(rec.Players))
-	for _, p := range rec.Players {
-		players = append(players, centrifugo.PlayerScore{UID: p.ID, Score: p.Score, WordsCount: len(p.Words)})
+	scores := rec.Game.PlayerScores()
+	players := make([]centrifugo.PlayerScore, 0, len(scores))
+	for _, s := range scores {
+		players = append(players, centrifugo.PlayerScore{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount})
 	}
 	if currentTurnUID == "" {
 		currentTurnUID = rec.Game.CurrentPlayerID()


### PR DESCRIPTION
- Queue Centrifugo subscriptions before connect() to fix race condition causing EvLobbyUpdate to be missed (lobby never refreshed).
- Fix buildGameState to use rec.Game.PlayerScores() instead of stale rec.Players, preventing opponent score and words count from resetting after each move.
- Minor frontend improvements for game screen and board interactions.