### PR TITLE
add player word list and fix board-full game ending

### DIFF
--- a/api/openapi/http-api.yaml
+++ b/api/openapi/http-api.yaml
@@ -575,13 +575,13 @@ components:
         players:
           type: array
           items:
-            $ref: "#/components/schemas/PlayerScore"
+            $ref: "#/components/schemas/PlayerGameState"
         status:
           $ref: "#/components/schemas/GameStatus"
         move_number:
           type: integer
 
-    PlayerScore:
+    PlayerGameState:
       type: object
       properties:
         uid:
@@ -594,6 +594,11 @@ components:
         words_count:
           description: Number of words submitted by the player
           type: integer
+        words:
+          description: List of words submitted by the player in this game
+          type: array
+          items:
+            type: string
 
     EvGameCreated:
       type: object
@@ -646,7 +651,7 @@ components:
         players:
           type: array
           items:
-            $ref: "#/components/schemas/PlayerScore"
+            $ref: "#/components/schemas/PlayerGameState"
         status:
           $ref: "#/components/schemas/GameStatus"
         move_number:
@@ -671,7 +676,7 @@ components:
         players:
           type: array
           items:
-            $ref: "#/components/schemas/PlayerScore"
+            $ref: "#/components/schemas/PlayerGameState"
 
     PlayerState:
       type: object

--- a/frontend/src/components/GameScreen.svelte
+++ b/frontend/src/components/GameScreen.svelte
@@ -124,6 +124,7 @@
         name={p.nickname}
         score={p.score}
         wordsCount={p.wordsCount}
+        words={p.words}
         consecutiveSkips={p.consecutiveSkips}
         isActive={gameState.currentTurnUid === p.uid}
         isWinner={gameState.phase === 'finished' && gameState.winnerUid === p.uid}

--- a/frontend/src/components/Lobby.svelte
+++ b/frontend/src/components/Lobby.svelte
@@ -38,7 +38,7 @@
           game_id: res.game.id,
           board: res.board,
           current_turn_uid: res.current_turn_uid,
-          players: res.game.player_ids.map((uid) => ({ uid, score: 0 })),
+          players: res.game.player_ids.map((uid) => ({ uid, score: 0, words_count: 0, words: [] })),
           status: 'in_progress',
           move_number: 0,
         });

--- a/frontend/src/components/PlayerCard.svelte
+++ b/frontend/src/components/PlayerCard.svelte
@@ -7,12 +7,19 @@
     name: string;
     score: number;
     wordsCount: number;
+    words?: string[];
     consecutiveSkips?: number;
     isActive?: boolean;
     isWinner?: boolean;
   }
 
-  let { name, score, wordsCount, consecutiveSkips = 0, isActive = false, isWinner = false }: Props = $props();
+  let { name, score, wordsCount, words = [], consecutiveSkips = 0, isActive = false, isWinner = false }: Props = $props();
+
+  let showWords = $state(false);
+
+  function toggleWords() {
+    if (words.length > 0) showWords = !showWords;
+  }
 </script>
 
 <div class="flex-1 rounded-2xl p-4 text-center transition-all {isActive ? 'bg-blue-50 ring-2 ring-blue-500' : 'bg-stone-100'}">
@@ -23,9 +30,23 @@
     {name}
   </div>
   <div class="text-2xl font-extrabold text-blue-600">{score}</div>
-  <div class="mt-1 text-xs text-stone-500">
+  <button
+    class="mt-1 text-xs text-stone-500 {words.length > 0 ? 'cursor-pointer hover:text-blue-500' : 'cursor-default'}"
+    onclick={toggleWords}
+    type="button"
+  >
     {wordsCount} {wordsCount === 1 ? 'слово' : wordsCount < 5 ? 'слова' : 'слов'}
-  </div>
+    {#if words.length > 0}
+      <span class="ml-0.5">{showWords ? '▲' : '▼'}</span>
+    {/if}
+  </button>
+  {#if showWords && words.length > 0}
+    <ul class="mt-2 max-h-32 overflow-y-auto text-left text-xs text-stone-600">
+      {#each words as word}
+        <li class="truncate px-1 py-0.5 odd:bg-stone-200/50">{word}</li>
+      {/each}
+    </ul>
+  {/if}
   {#if consecutiveSkips > 0}
     <div class="mt-2 flex items-center justify-center gap-1" title="Пропуски подряд: {consecutiveSkips}/{MAX_SKIPS}">
       {#each Array(MAX_SKIPS) as _, i}

--- a/frontend/src/stores/game.svelte.ts
+++ b/frontend/src/stores/game.svelte.ts
@@ -1,4 +1,4 @@
-import type { GameSummary, PlayerState, EvGameState, EvGameOver, EvTurnChange, EvSkipWarn, EvLobbyUpdate, MoveResponse } from '../types';
+import type { GameSummary, PlayerState, PlayerGameState, EvGameState, EvGameOver, EvTurnChange, EvSkipWarn, EvLobbyUpdate, MoveResponse } from '../types';
 
 export type GamePhase = 'auth' | 'lobby' | 'waiting' | 'playing' | 'finished';
 
@@ -7,6 +7,7 @@ export interface PlayerInfo {
   nickname: string;
   score: number;
   wordsCount: number;
+  words: string[];
   consecutiveSkips: number;
 }
 
@@ -88,24 +89,28 @@ export function createGameState() {
       nickname: uid === playerUid ? nickname : 'Соперник',
       score: 0,
       wordsCount: 0,
+      words: [],
       consecutiveSkips: 0,
     }));
+  }
+
+  function mergePlayerState(p: PlayerGameState): PlayerInfo {
+    const existing = players.find((ep) => ep.uid === p.uid);
+    return {
+      uid: p.uid,
+      nickname: existing?.nickname || (p.uid === playerUid ? nickname : 'Соперник'),
+      score: p.score,
+      wordsCount: p.words_count ?? 0,
+      words: p.words ?? existing?.words ?? [],
+      consecutiveSkips: existing?.consecutiveSkips ?? 0,
+    };
   }
 
   function applyGameState(ev: EvGameState) {
     board = ev.board;
     currentTurnUid = ev.current_turn_uid;
     moveNumber = ev.move_number;
-    players = ev.players.map((p) => {
-      const existing = players.find((ep) => ep.uid === p.uid);
-      return {
-        uid: p.uid,
-        nickname: existing?.nickname || (p.uid === playerUid ? nickname : 'Соперник'),
-        score: p.score,
-        wordsCount: p.words_count ?? 0,
-        consecutiveSkips: existing?.consecutiveSkips ?? 0,
-      };
-    });
+    players = ev.players.map(mergePlayerState);
     if (ev.status === 'finished') {
       phase = 'finished';
     }
@@ -119,16 +124,7 @@ export function createGameState() {
   function finishGame(ev: EvGameOver) {
     phase = 'finished';
     winnerUid = ev.winner_uid;
-    players = ev.players.map((p) => {
-      const existing = players.find((ep) => ep.uid === p.uid);
-      return {
-        uid: p.uid,
-        nickname: existing?.nickname || (p.uid === playerUid ? nickname : 'Соперник'),
-        score: p.score,
-        wordsCount: p.words_count ?? 0,
-        consecutiveSkips: existing?.consecutiveSkips ?? 0,
-      };
-    });
+    players = ev.players.map(mergePlayerState);
   }
 
   function applySkipWarn(ev: EvSkipWarn) {
@@ -149,16 +145,7 @@ export function createGameState() {
     board = resp.board;
     currentTurnUid = resp.current_turn_uid;
     moveNumber = resp.move_number;
-    players = resp.players.map((p) => {
-      const existing = players.find((ep) => ep.uid === p.uid);
-      return {
-        uid: p.uid,
-        nickname: existing?.nickname || (p.uid === playerUid ? nickname : 'Соперник'),
-        score: p.score,
-        wordsCount: p.words_count ?? 0,
-        consecutiveSkips: 0,
-      };
-    });
+    players = resp.players.map((p) => ({ ...mergePlayerState(p), consecutiveSkips: 0 }));
     if (resp.status === 'finished') {
       phase = 'finished';
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -57,10 +57,11 @@ export interface ListGamesResponse {
   games: GameSummary[];
 }
 
-export interface PlayerScore {
+export interface PlayerGameState {
   uid: string;
   score: number;
   words_count: number;
+  words?: string[];
 }
 
 export interface PlayerState {
@@ -77,7 +78,7 @@ export interface EvGameState {
   game_id: string;
   board: string[][];
   current_turn_uid: string;
-  players: PlayerScore[];
+  players: PlayerGameState[];
   status: GameStatus;
   move_number: number;
 }
@@ -86,7 +87,7 @@ export interface EvGameOver {
   type: 'game_over';
   game_id: string;
   winner_uid?: string | null;
-  players: PlayerScore[];
+  players: PlayerGameState[];
 }
 
 export interface EvGameCreated {
@@ -128,7 +129,7 @@ export interface MoveRequest {
 export interface MoveResponse {
   board: string[][];
   current_turn_uid: string;
-  players: PlayerScore[];
+  players: PlayerGameState[];
   status: GameStatus;
   move_number: number;
 }

--- a/internal/centrifugo/events.go
+++ b/internal/centrifugo/events.go
@@ -38,11 +38,12 @@ type EvGameStarted struct {
 	StartedAt int64    `json:"started_at"`
 }
 
-// PlayerScore holds a player's uid and current score for EvGameState.
-type PlayerScore struct {
-	UID        string `json:"uid"`
-	Score      int    `json:"score"`
-	WordsCount int    `json:"words_count"`
+// PlayerState holds a player's uid and current score for EvGameState.
+type PlayerState struct {
+	UID        string   `json:"uid"`
+	Score      int      `json:"score"`
+	WordsCount int      `json:"words_count"`
+	Words      []string `json:"words"`
 }
 
 // EvGameState carries the full board snapshot sent after game_started and after each move.
@@ -51,7 +52,7 @@ type EvGameState struct {
 	GameID         string        `json:"game_id"`
 	Board          [5][5]string  `json:"board"`
 	CurrentTurnUID string        `json:"current_turn_uid"`
-	Players        []PlayerScore `json:"players"`
+	Players        []PlayerState `json:"players"`
 	Status         string        `json:"status"`
 	MoveNumber     int           `json:"move_number"`
 }
@@ -81,5 +82,5 @@ type EvGameOver struct {
 	Type      string        `json:"type"`
 	GameID    string        `json:"game_id"`
 	WinnerUID string        `json:"winner_uid,omitempty"`
-	Players   []PlayerScore `json:"players"`
+	Players   []PlayerState `json:"players"`
 }

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -46,6 +46,7 @@ type Notifier interface {
 	NotifyTimeout(playerID string, consecutive int, willKick bool)
 	NotifySkip(playerID string, consecutive int, willEnd bool)
 	NotifyKick(playerID string)
+	NotifyBoardFull()
 	NotifyTurnStart(playerID string)
 }
 
@@ -241,8 +242,7 @@ func (g *Game) onKick() {
 }
 
 func (g *Game) onBoardFull() {
-	// Board is full; game ends naturally.
-	// StateGameOver committed by dispatch; shutdown follows in Run.
+	g.notifier.NotifyBoardFull()
 }
 
 func (g *Game) currentPlayer() *Player { return g.players[g.current] }
@@ -380,20 +380,23 @@ func (g *Game) Board() *LettersTable {
 	return g.board
 }
 
-// PlayerScore holds a player's UID and current score for external consumers.
-type PlayerScore struct {
+// PlayerState holds a player's UID and current score for external consumers.
+type PlayerState struct {
 	UID        string
 	Score      int
 	WordsCount int
+	Words      []string
 }
 
 // PlayerScores returns a snapshot of each player's score and word count.
-func (g *Game) PlayerScores() []PlayerScore {
+func (g *Game) PlayerScores() []PlayerState {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	out := make([]PlayerScore, len(g.players))
+	out := make([]PlayerState, len(g.players))
 	for i, p := range g.players {
-		out[i] = PlayerScore{UID: p.ID, Score: p.Score, WordsCount: len(p.Words)}
+		words := make([]string, len(p.Words))
+		copy(words, p.Words)
+		out[i] = PlayerState{UID: p.ID, Score: p.Score, WordsCount: len(p.Words), Words: words}
 	}
 	return out
 }

--- a/internal/game/game_test/game_fsm_test.go
+++ b/internal/game/game_test/game_fsm_test.go
@@ -13,10 +13,11 @@ import (
 
 // mockNotifier captures all notifications for assertion in tests.
 type mockNotifier struct {
-	mu         sync.Mutex
-	timeouts   []timeoutCall
-	kicks      []string
-	turnStarts []string
+	mu          sync.Mutex
+	timeouts    []timeoutCall
+	kicks       []string
+	turnStarts  []string
+	boardFulls  int
 }
 
 type timeoutCall struct {
@@ -32,6 +33,12 @@ func (m *mockNotifier) NotifyTimeout(playerID string, consecutive int, willKick 
 }
 
 func (m *mockNotifier) NotifySkip(_ string, _ int, _ bool) {}
+
+func (m *mockNotifier) NotifyBoardFull() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.boardFulls++
+}
 
 func (m *mockNotifier) NotifyKick(playerID string) {
 	m.mu.Lock()
@@ -58,6 +65,12 @@ func (m *mockNotifier) turnStartCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.turnStarts)
+}
+
+func (m *mockNotifier) boardFullCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.boardFulls
 }
 
 func (m *mockNotifier) timeoutCount() int {
@@ -232,59 +245,87 @@ func TestGame_Run_ExplicitKickEndsGame(t *testing.T) {
 	assert.True(t, players[0].Kicked)
 }
 
-func TestGame_Run_BoardFullEndsGame(t *testing.T) {
-	n := &mockNotifier{}
-	players := makePlayers("p1", "p2")
-	g, err := game.NewGameWithWord(players, testBoardWord, n)
-	require.NoError(t, err)
-	addTestWord(t, "аб")
-
-	// Fill the entire board except one cell (3,3).
+// fillBoardExcept fills every cell of the board with "я" except the given cell.
+// Must be called before g.Run to avoid data races.
+func fillBoardExcept(g *game.Game, skipRow, skipCol uint8) {
 	board := g.Board()
 	for r := range board.Table {
 		for c := range board.Table[r] {
-			if board.Table[r][c] == nil {
+			if board.Table[r][c] == nil && !(uint8(r) == skipRow && uint8(c) == skipCol) {
 				board.Table[r][c] = &game.Letter{RowID: uint8(r), ColID: uint8(c), Char: "я"}
 			}
 		}
 	}
-	// Clear the target cell so the final move can place a letter there.
-	board.Table[3][3] = nil
+}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		g.Run(ctx)
-	}()
-
-	require.Eventually(t, func() bool {
-		return n.turnStartCount() >= 1
-	}, time.Second, 5*time.Millisecond)
-	assert.Equal(t, "p1", n.lastTurnStart())
-
-	// Submit a word that fills the last empty cell (3,3).
-	// Word path: н(2,3) → new letter б(3,3). Word is "аб" where 'а' is existing 'н'???
-	// Wait, MakeWord uses Char from letters. Let's use actual chars.
-	// Actually let's just use letters with Char matching the word "аб".
-	// But (2,3) has Char 'н'. So the word formed by the path would be "нб", not "аб".
-	// We need the word formed by the path to be in the dictionary.
-	// So let's add "нб" to the dictionary instead.
+// submitLastMove places "б" at (3,3) adjacent to н(2,3), forming word "нб".
+func submitLastMove(t *testing.T, g *game.Game, playerID string) {
+	t.Helper()
 	addTestWord(t, "нб")
-	lastLetter := game.Letter{RowID: 3, ColID: 3, Char: "б"}
-	word := []game.Letter{
+	nl := game.Letter{RowID: 3, ColID: 3, Char: "б"}
+	path := []game.Letter{
 		{RowID: 2, ColID: 3, Char: "н"},
 		{RowID: 3, ColID: 3, Char: "б"},
 	}
-	require.NoError(t, g.SubmitWord("p1", &lastLetter, word))
+	require.NoError(t, g.SubmitWord(playerID, &nl, path))
+}
 
+// waitRunDone is a helper that asserts game.Run exits within 2 s.
+func waitRunDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("game did not end after board became full")
+		t.Fatal("game did not stop")
 	}
+}
+
+func TestGame_Run_BoardFull_StopsGame(t *testing.T) {
+	n := &mockNotifier{}
+	g, err := game.NewGameWithWord(makePlayers("p1", "p2"), testBoardWord, n)
+	require.NoError(t, err)
+	fillBoardExcept(g, 3, 3)
+
+	done := make(chan struct{})
+	go func() { defer close(done); g.Run(t.Context()) }()
+
+	require.Eventually(t, func() bool { return n.turnStartCount() >= 1 }, time.Second, 5*time.Millisecond)
+	submitLastMove(t, g, "p1")
+
+	waitRunDone(t, done)
+}
+
+func TestGame_Run_BoardFull_CallsNotifyBoardFull(t *testing.T) {
+	n := &mockNotifier{}
+	g, err := game.NewGameWithWord(makePlayers("p1", "p2"), testBoardWord, n)
+	require.NoError(t, err)
+	fillBoardExcept(g, 3, 3)
+
+	done := make(chan struct{})
+	go func() { defer close(done); g.Run(t.Context()) }()
+
+	require.Eventually(t, func() bool { return n.turnStartCount() >= 1 }, time.Second, 5*time.Millisecond)
+	submitLastMove(t, g, "p1")
+
+	waitRunDone(t, done)
+	assert.Equal(t, 1, n.boardFullCount(), "NotifyBoardFull must be called exactly once")
+}
+
+func TestGame_Run_BoardFull_TurnDoesNotAdvance(t *testing.T) {
+	n := &mockNotifier{}
+	g, err := game.NewGameWithWord(makePlayers("p1", "p2"), testBoardWord, n)
+	require.NoError(t, err)
+	fillBoardExcept(g, 3, 3)
+
+	done := make(chan struct{})
+	go func() { defer close(done); g.Run(t.Context()) }()
+
+	require.Eventually(t, func() bool { return n.turnStartCount() >= 1 }, time.Second, 5*time.Millisecond)
+	turnsBeforeMove := n.turnStartCount()
+	submitLastMove(t, g, "p1")
+
+	waitRunDone(t, done)
+	assert.Equal(t, turnsBeforeMove, n.turnStartCount(), "turn must not advance after board is full")
 }
 
 func TestGame_Run_ContextCancellationStopsGame(t *testing.T) {

--- a/internal/gamecoord/coord.go
+++ b/internal/gamecoord/coord.go
@@ -90,6 +90,12 @@ func (c *Coordinator) NotifyKick(kickedPlayerID string) {
 	go c.publishGameOver(kickedPlayerID)
 }
 
+// NotifyBoardFull is called when the last empty cell on the board is filled.
+// The winner is the player with the higher score; equal scores mean a draw.
+func (c *Coordinator) NotifyBoardFull() {
+	go c.publishBoardFullGameOver()
+}
+
 func (c *Coordinator) publishTurnChange(playerID, reason string) {
 	ev := centrifugo.EvTurnChange{
 		Type:           "turn_change",
@@ -110,9 +116,9 @@ func (c *Coordinator) publishGameState() {
 	currentTurn := c.g.CurrentPlayerID()
 	moveNum := c.g.MoveNumber()
 
-	players := make([]centrifugo.PlayerScore, len(scores))
+	players := make([]centrifugo.PlayerState, len(scores))
 	for i, s := range scores {
-		players[i] = centrifugo.PlayerScore{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount}
+		players[i] = centrifugo.PlayerState{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount, Words: s.Words}
 	}
 
 	ev := centrifugo.EvGameState{
@@ -147,13 +153,44 @@ func (c *Coordinator) publishSkipWarn(playerID string, skipsUsed, skipsLeft int)
 	}
 }
 
+func (c *Coordinator) publishBoardFullGameOver() {
+	scores := c.g.PlayerScores()
+
+	winnerUID := ""
+	if len(scores) == 2 {
+		if scores[0].Score > scores[1].Score {
+			winnerUID = scores[0].UID
+		} else if scores[1].Score > scores[0].Score {
+			winnerUID = scores[1].UID
+		}
+	}
+
+	players := make([]centrifugo.PlayerState, len(scores))
+	for i, s := range scores {
+		players[i] = centrifugo.PlayerState{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount, Words: s.Words}
+	}
+
+	ev := centrifugo.EvGameOver{
+		Type:      "game_over",
+		GameID:    c.gameID,
+		WinnerUID: winnerUID,
+		Players:   players,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := c.cf.Publish(ctx, centrifugo.ChannelGame(c.gameID), ev); err != nil {
+		slog.Error("gamecoord: publish game_over (board full)", slog.String("gameID", c.gameID), slog.Any("error", err))
+	}
+}
+
 func (c *Coordinator) publishGameOver(kickedPlayerID string) {
 	scores := c.g.PlayerScores()
 
 	winnerUID := ""
-	players := make([]centrifugo.PlayerScore, len(scores))
+	players := make([]centrifugo.PlayerState, len(scores))
 	for i, s := range scores {
-		players[i] = centrifugo.PlayerScore{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount}
+		players[i] = centrifugo.PlayerState{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount, Words: s.Words}
 		if s.UID != kickedPlayerID {
 			winnerUID = s.UID
 		}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -86,6 +86,8 @@ func (n *GameNotifier) NotifyKick(playerID string) {
 	n.sender.Send(playerID, Event{Type: EventKick})
 }
 
+func (n *GameNotifier) NotifyBoardFull() {}
+
 func (n *GameNotifier) NotifyTurnStart(playerID string) {
 	n.sender.Send(playerID, Event{Type: EventTurnStart})
 }
@@ -96,4 +98,5 @@ type Noop struct{}
 func (n *Noop) NotifyTimeout(_ string, _ int, _ bool) {}
 func (n *Noop) NotifySkip(_ string, _ int, _ bool)    {}
 func (n *Noop) NotifyKick(_ string)                   {}
+func (n *Noop) NotifyBoardFull()                      {}
 func (n *Noop) NotifyTurnStart(_ string)              {}

--- a/internal/server/ogen/oas_json_gen.go
+++ b/internal/server/ogen/oas_json_gen.go
@@ -1520,9 +1520,9 @@ func (s *MoveResponse) Decode(d *jx.Decoder) error {
 			}
 		case "players":
 			if err := func() error {
-				s.Players = make([]PlayerScore, 0)
+				s.Players = make([]PlayerGameState, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
-					var elem PlayerScore
+					var elem PlayerGameState
 					if err := elem.Decode(d); err != nil {
 						return err
 					}
@@ -1950,14 +1950,14 @@ func (s *Player) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
-func (s *PlayerScore) Encode(e *jx.Encoder) {
+func (s *PlayerGameState) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
 	e.ObjEnd()
 }
 
 // encodeFields encodes fields.
-func (s *PlayerScore) encodeFields(e *jx.Encoder) {
+func (s *PlayerGameState) encodeFields(e *jx.Encoder) {
 	{
 		if s.UID.Set {
 			e.FieldStart("uid")
@@ -1976,18 +1976,29 @@ func (s *PlayerScore) encodeFields(e *jx.Encoder) {
 			s.WordsCount.Encode(e)
 		}
 	}
+	{
+		if s.Words != nil {
+			e.FieldStart("words")
+			e.ArrStart()
+			for _, elem := range s.Words {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
 }
 
-var jsonFieldsNameOfPlayerScore = [3]string{
+var jsonFieldsNameOfPlayerGameState = [4]string{
 	0: "uid",
 	1: "score",
 	2: "words_count",
+	3: "words",
 }
 
-// Decode decodes PlayerScore from json.
-func (s *PlayerScore) Decode(d *jx.Decoder) error {
+// Decode decodes PlayerGameState from json.
+func (s *PlayerGameState) Decode(d *jx.Decoder) error {
 	if s == nil {
-		return errors.New("invalid: unable to decode PlayerScore to nil")
+		return errors.New("invalid: unable to decode PlayerGameState to nil")
 	}
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
@@ -2022,26 +2033,45 @@ func (s *PlayerScore) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"words_count\"")
 			}
+		case "words":
+			if err := func() error {
+				s.Words = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Words = append(s.Words, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"words\"")
+			}
 		default:
 			return d.Skip()
 		}
 		return nil
 	}); err != nil {
-		return errors.Wrap(err, "decode PlayerScore")
+		return errors.Wrap(err, "decode PlayerGameState")
 	}
 
 	return nil
 }
 
 // MarshalJSON implements stdjson.Marshaler.
-func (s *PlayerScore) MarshalJSON() ([]byte, error) {
+func (s *PlayerGameState) MarshalJSON() ([]byte, error) {
 	e := jx.Encoder{}
 	s.Encode(&e)
 	return e.Bytes(), nil
 }
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *PlayerScore) UnmarshalJSON(data []byte) error {
+func (s *PlayerGameState) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/server/ogen/oas_schemas_gen.go
+++ b/internal/server/ogen/oas_schemas_gen.go
@@ -497,10 +497,10 @@ type MoveResponse struct {
 	// Updated 5x5 board state.
 	Board [][]string `json:"board"`
 	// ID of the player whose turn it is now.
-	CurrentTurnUID OptUUID       `json:"current_turn_uid"`
-	Players        []PlayerScore `json:"players"`
-	Status         OptGameStatus `json:"status"`
-	MoveNumber     OptInt        `json:"move_number"`
+	CurrentTurnUID OptUUID           `json:"current_turn_uid"`
+	Players        []PlayerGameState `json:"players"`
+	Status         OptGameStatus     `json:"status"`
+	MoveNumber     OptInt            `json:"move_number"`
 }
 
 // GetBoard returns the value of Board.
@@ -514,7 +514,7 @@ func (s *MoveResponse) GetCurrentTurnUID() OptUUID {
 }
 
 // GetPlayers returns the value of Players.
-func (s *MoveResponse) GetPlayers() []PlayerScore {
+func (s *MoveResponse) GetPlayers() []PlayerGameState {
 	return s.Players
 }
 
@@ -539,7 +539,7 @@ func (s *MoveResponse) SetCurrentTurnUID(val OptUUID) {
 }
 
 // SetPlayers sets the value of Players.
-func (s *MoveResponse) SetPlayers(val []PlayerScore) {
+func (s *MoveResponse) SetPlayers(val []PlayerGameState) {
 	s.Players = val
 }
 
@@ -969,44 +969,56 @@ func (s *Player) SetKey(val OptString) {
 	s.Key = val
 }
 
-// Ref: #/components/schemas/PlayerScore
-type PlayerScore struct {
+// Ref: #/components/schemas/PlayerGameState
+type PlayerGameState struct {
 	// Player's ID.
 	UID OptUUID `json:"uid"`
 	// Number of points scored in the current game.
 	Score OptInt `json:"score"`
 	// Number of words submitted by the player.
 	WordsCount OptInt `json:"words_count"`
+	// List of words submitted by the player in this game.
+	Words []string `json:"words"`
 }
 
 // GetUID returns the value of UID.
-func (s *PlayerScore) GetUID() OptUUID {
+func (s *PlayerGameState) GetUID() OptUUID {
 	return s.UID
 }
 
 // GetScore returns the value of Score.
-func (s *PlayerScore) GetScore() OptInt {
+func (s *PlayerGameState) GetScore() OptInt {
 	return s.Score
 }
 
 // GetWordsCount returns the value of WordsCount.
-func (s *PlayerScore) GetWordsCount() OptInt {
+func (s *PlayerGameState) GetWordsCount() OptInt {
 	return s.WordsCount
 }
 
+// GetWords returns the value of Words.
+func (s *PlayerGameState) GetWords() []string {
+	return s.Words
+}
+
 // SetUID sets the value of UID.
-func (s *PlayerScore) SetUID(val OptUUID) {
+func (s *PlayerGameState) SetUID(val OptUUID) {
 	s.UID = val
 }
 
 // SetScore sets the value of Score.
-func (s *PlayerScore) SetScore(val OptInt) {
+func (s *PlayerGameState) SetScore(val OptInt) {
 	s.Score = val
 }
 
 // SetWordsCount sets the value of WordsCount.
-func (s *PlayerScore) SetWordsCount(val OptInt) {
+func (s *PlayerGameState) SetWordsCount(val OptInt) {
 	s.WordsCount = val
+}
+
+// SetWords sets the value of Words.
+func (s *PlayerGameState) SetWords(val []string) {
+	s.Words = val
 }
 
 // Ref: #/components/schemas/PlayerState

--- a/internal/server/restapi/handlers/join_game.go
+++ b/internal/server/restapi/handlers/join_game.go
@@ -101,9 +101,9 @@ func (h *Handlers) JoinGame(ctx context.Context, params baldaapi.JoinGameParams)
 	h.publishLobbyUpdate(ctx)
 
 	// Publish the initial board state so clients render the starting word immediately.
-	players := make([]centrifugo.PlayerScore, 0, len(rec.Players))
+	players := make([]centrifugo.PlayerState, 0, len(rec.Players))
 	for _, p := range rec.Players {
-		players = append(players, centrifugo.PlayerScore{UID: p.ID, Score: 0, WordsCount: 0})
+		players = append(players, centrifugo.PlayerState{UID: p.ID, Score: 0, WordsCount: 0, Words: []string{}})
 	}
 	// The creator (index 0) always moves first.
 	firstPlayerID := ""

--- a/internal/server/restapi/handlers/move_game.go
+++ b/internal/server/restapi/handlers/move_game.go
@@ -85,10 +85,23 @@ func (h *Handlers) MoveGame(ctx context.Context, req *baldaapi.MoveRequest, para
 		}
 	}
 
+	scores := rec.Game.PlayerScores()
+	boardFull := rec.Game.Board().IsFull()
+
+	if boardFull {
+		// gamecoord.NotifyBoardFull will publish game_over via Centrifugo.
+		return &baldaapi.MoveResponse{
+			Board:   boardToSlice(rec.Game.Board().AsStrings()),
+			Players: playerScoresToAPI(scores),
+			Status:  baldaapi.NewOptGameStatus(baldaapi.GameStatusFinished),
+			MoveNumber: baldaapi.NewOptInt(rec.Game.MoveNumber()),
+		}, nil
+	}
+
 	// The game's FSM processes the turn advance asynchronously.
 	// Compute the next player deterministically so the response matches the
 	// eventual server state even if the FSM hasn't advanced yet.
-	nextTurnUID := nextPlayerID(moverID, rec.Game.PlayerScores())
+	nextTurnUID := nextPlayerID(moverID, scores)
 
 	// Publish updated game state to the game channel.
 	gameState := buildGameState(rec, nextTurnUID)
@@ -104,7 +117,7 @@ func (h *Handlers) MoveGame(ctx context.Context, req *baldaapi.MoveRequest, para
 	return &baldaapi.MoveResponse{
 		Board:          boardToSlice(rec.Game.Board().AsStrings()),
 		CurrentTurnUID: baldaapi.NewOptUUID(nextUID),
-		Players:        playerScoresToAPI(rec.Game.PlayerScores()),
+		Players:        playerScoresToAPI(scores),
 		Status:         baldaapi.NewOptGameStatus(baldaapi.GameStatusInProgress),
 		MoveNumber:     baldaapi.NewOptInt(rec.Game.MoveNumber()),
 	}, nil
@@ -120,23 +133,24 @@ func boardToSlice(board [5][5]string) [][]string {
 	return out
 }
 
-func playerScoresToAPI(scores []game.PlayerScore) []baldaapi.PlayerScore {
-	out := make([]baldaapi.PlayerScore, 0, len(scores))
+func playerScoresToAPI(scores []game.PlayerState) []baldaapi.PlayerGameState {
+	out := make([]baldaapi.PlayerGameState, 0, len(scores))
 	for _, ps := range scores {
 		pid, err := uuid.Parse(ps.UID)
 		if err != nil {
 			continue
 		}
-		out = append(out, baldaapi.PlayerScore{
+		out = append(out, baldaapi.PlayerGameState{
 			UID:        baldaapi.NewOptUUID(pid),
 			Score:      baldaapi.NewOptInt(ps.Score),
 			WordsCount: baldaapi.NewOptInt(ps.WordsCount),
+			Words:      ps.Words,
 		})
 	}
 	return out
 }
 
-func nextPlayerID(moverID string, players []game.PlayerScore) string {
+func nextPlayerID(moverID string, players []game.PlayerState) string {
 	for i, p := range players {
 		if p.UID == moverID {
 			return players[(i+1)%len(players)].UID
@@ -147,9 +161,9 @@ func nextPlayerID(moverID string, players []game.PlayerScore) string {
 
 func buildGameState(rec *lobby.GameRecord, currentTurnUID string) centrifugo.EvGameState {
 	scores := rec.Game.PlayerScores()
-	players := make([]centrifugo.PlayerScore, 0, len(scores))
+	players := make([]centrifugo.PlayerState, 0, len(scores))
 	for _, s := range scores {
-		players = append(players, centrifugo.PlayerScore{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount})
+		players = append(players, centrifugo.PlayerState{UID: s.UID, Score: s.Score, WordsCount: s.WordsCount, Words: s.Words})
 	}
 	if currentTurnUID == "" {
 		currentTurnUID = rec.Game.CurrentPlayerID()


### PR DESCRIPTION
- Rename PlayerScore -> PlayerGameState (API/ogen) and PlayerState (game/centrifugo packages) to better reflect the data carried
- Add words []string field so each player's submitted words are included in game_state and game_over events
- Fix: board full no longer silently drops the game; NotifyBoardFull is called, gamecoord publishes game_over with the correct winner (higher score wins, draw if equal)
- Fix move_game handler: returns status=finished on the last move instead of advancing the turn with in_progress
- PlayerCard: clicking the score area toggles an inline word list
- Add three FSM tests: StopsGame, CallsNotifyBoardFull, TurnDoesNotAdvance