### PR TITLE
fix: remove duplicate game_state publish on game start

### DIFF
--- a/internal/server/restapi/handlers/join_game.go
+++ b/internal/server/restapi/handlers/join_game.go
@@ -105,27 +105,10 @@ func (h *Handlers) JoinGame(ctx context.Context, params baldaapi.JoinGameParams)
 	}
 	h.publishLobbyUpdate(ctx)
 
-	// Publish the initial board state so clients render the starting word immediately.
-	players := make([]centrifugo.PlayerState, 0, len(rec.Players))
-	for _, p := range rec.Players {
-		players = append(players, centrifugo.PlayerState{UID: p.ID, Exp: p.Exp, Score: 0, WordsCount: 0, Words: []string{}})
-	}
 	// The creator (index 0) always moves first.
 	firstPlayerID := ""
 	if len(rec.Players) > 0 {
 		firstPlayerID = rec.Players[0].ID
-	}
-	gameState := centrifugo.EvGameState{
-		Type:           "game_state",
-		GameID:         rec.ID,
-		Board:          rec.Game.Board().AsStrings(),
-		CurrentTurnUID: firstPlayerID,
-		Players:        players,
-		Status:         "in_progress",
-		MoveNumber:     0,
-	}
-	if err := h.cf.Publish(ctx, centrifugo.ChannelGame(rec.ID), gameState); err != nil {
-		slog.Error("join_game: publish initial game state", slog.Any("error", err))
 	}
 
 	gameToken, err := centrifugo.GenerateSubscriptionToken(


### PR DESCRIPTION
gamecoord.NotifyTurnStart already publishes game_state with reason "game_start" when game.Run begins; the manual publish in JoinGame was redundant and caused the creator to receive the same event twice.