### PR TITLE
fix: return 500 instead of 409/400 on unexpected internal errors

### DIFF
--- a/api/openapi/http-api.yaml
+++ b/api/openapi/http-api.yaml
@@ -182,6 +182,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
   /games/{id}/move:
     post:
@@ -237,6 +239,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
   /games/{id}/propose-end:
     post:
@@ -443,6 +447,16 @@ components:
             status: 401
             message: "Session required"
             type: "Unauthorized"
+    InternalServerError:
+      description: Unexpected internal server error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            status: 500
+            message: "internal server error"
+            type: "InternalServerError"
 
   schemas:
     Error:

--- a/internal/server/ogen/oas_json_gen.go
+++ b/internal/server/ogen/oas_json_gen.go
@@ -862,6 +862,44 @@ func (s *JoinGameConflict) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes JoinGameInternalServerError as json.
+func (s *JoinGameInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes JoinGameInternalServerError from json.
+func (s *JoinGameInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode JoinGameInternalServerError to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = JoinGameInternalServerError(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *JoinGameInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *JoinGameInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes JoinGameNotFound as json.
 func (s *JoinGameNotFound) Encode(e *jx.Encoder) {
 	unwrapped := (*ErrorResponse)(s)
@@ -1303,6 +1341,44 @@ func (s *MoveGameConflict) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *MoveGameConflict) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes MoveGameInternalServerError as json.
+func (s *MoveGameInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes MoveGameInternalServerError from json.
+func (s *MoveGameInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode MoveGameInternalServerError to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = MoveGameInternalServerError(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *MoveGameInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *MoveGameInternalServerError) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/server/ogen/oas_response_decoders_gen.go
+++ b/internal/server/ogen/oas_response_decoders_gen.go
@@ -517,6 +517,41 @@ func decodeJoinGameResponse(resp *http.Response) (res JoinGameRes, _ error) {
 		default:
 			return res, validate.InvalidContentType(ct)
 		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response JoinGameInternalServerError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
@@ -772,6 +807,41 @@ func decodeMoveGameResponse(resp *http.Response) (res MoveGameRes, _ error) {
 			d := jx.DecodeBytes(buf)
 
 			var response MoveGameConflict
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response MoveGameInternalServerError
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err

--- a/internal/server/ogen/oas_response_encoders_gen.go
+++ b/internal/server/ogen/oas_response_encoders_gen.go
@@ -218,6 +218,19 @@ func encodeJoinGameResponse(response JoinGameRes, w http.ResponseWriter, span tr
 
 		return nil
 
+	case *JoinGameInternalServerError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -314,6 +327,19 @@ func encodeMoveGameResponse(response MoveGameRes, w http.ResponseWriter, span tr
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(409)
 		span.SetStatus(codes.Error, http.StatusText(409))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *MoveGameInternalServerError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 
 		e := new(jx.Encoder)
 		response.Encode(e)

--- a/internal/server/ogen/oas_schemas_gen.go
+++ b/internal/server/ogen/oas_schemas_gen.go
@@ -365,6 +365,10 @@ type JoinGameConflict ErrorResponse
 
 func (*JoinGameConflict) joinGameRes() {}
 
+type JoinGameInternalServerError ErrorResponse
+
+func (*JoinGameInternalServerError) joinGameRes() {}
+
 type JoinGameNotFound ErrorResponse
 
 func (*JoinGameNotFound) joinGameRes() {}
@@ -480,6 +484,10 @@ func (*MoveGameBadRequest) moveGameRes() {}
 type MoveGameConflict ErrorResponse
 
 func (*MoveGameConflict) moveGameRes() {}
+
+type MoveGameInternalServerError ErrorResponse
+
+func (*MoveGameInternalServerError) moveGameRes() {}
 
 type MoveGameNotFound ErrorResponse
 

--- a/internal/server/restapi/handlers/join_game.go
+++ b/internal/server/restapi/handlers/join_game.go
@@ -57,9 +57,10 @@ func (h *Handlers) JoinGame(ctx context.Context, params baldaapi.JoinGameParams)
 			}, nil
 		default:
 			slog.Error("join_game: join", slog.Any("error", err))
-			return &baldaapi.JoinGameConflict{
+			return &baldaapi.JoinGameInternalServerError{
 				Status:  baldaapi.NewOptInt(http.StatusInternalServerError),
 				Message: baldaapi.NewOptString("failed to join game"),
+				Type:    baldaapi.NewOptString("InternalServerError"),
 			}, nil
 		}
 	}

--- a/internal/server/restapi/handlers/move_game.go
+++ b/internal/server/restapi/handlers/move_game.go
@@ -77,10 +77,10 @@ func (h *Handlers) MoveGame(ctx context.Context, req *baldaapi.MoveRequest, para
 			}, nil
 		default:
 			slog.Error("move_game: submit move", slog.Any("error", err))
-			return &baldaapi.MoveGameBadRequest{
+			return &baldaapi.MoveGameInternalServerError{
 				Status:  baldaapi.NewOptInt(http.StatusInternalServerError),
 				Message: baldaapi.NewOptString("failed to submit move"),
-				Type:    baldaapi.NewOptString("InternalError"),
+				Type:    baldaapi.NewOptString("InternalServerError"),
 			}, nil
 		}
 	}


### PR DESCRIPTION
Added InternalServerError to shared responses in the OpenAPI spec and wired it to joinGame and moveGame endpoints so the default error branch produces HTTP 500 rather than a misleading 409/400.