### PR TITLE
fix: errorlint and gosec issues found by new linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,8 @@ linters:
     - whitespace
     - prealloc
     - misspell
+    - errorlint
+    - contextcheck
 
   settings:
     gosec:
@@ -62,14 +64,9 @@ linters:
       # Disable linters that are annoying in tests.
       - path: _test\.go
         linters:
-          - gocyclo
           - errcheck
-          - dupl
           - gosec
-          - funlen
           - goconst
-          - gocognit
-          - lll
 
       - path: _test\.go
         text: "Combine"
@@ -98,11 +95,7 @@ linters:
       - linters: [revive]
         text: 'receiver-naming: receiver name \S+ should be consistent with previous receiver name \S+ for invalid-type'
 
-      - source: 'func Fuzz.+\(f \*testing\.F\)'
-        linters: [stylecheck]
-        text: "ST1003" # underscores lol
-
-      - path: (internal|grpcservice)
+      - path: internal
         linters: [revive]
         text: "package-comments"
 
@@ -118,8 +111,7 @@ formatters:
     goimports: {}
 
   exclusions:
-    paths:
-      - _test\.go
+    paths: []
 
 issues:
   max-issues-per-linter: 0

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -96,7 +96,7 @@ var serverCmd = &cobra.Command{
 		dbVersion, err := migrations.Migrate(10 * time.Second)
 		if err != nil {
 			slog.Error("failed to migrate database", slog.Any("error", err))
-			return fmt.Errorf("failed to migrate database: %v", err)
+			return fmt.Errorf("failed to migrate database: %w", err)
 		}
 
 		slog.Info("database migration success", slog.Int("db_version", dbVersion))
@@ -107,7 +107,7 @@ var serverCmd = &cobra.Command{
 		)
 		pool, err := pgxpool.New(cmd.Context(), connStr)
 		if err != nil {
-			return fmt.Errorf("connect to pg: %v", err)
+			return fmt.Errorf("connect to pg: %w", err)
 		}
 		defer pool.Close()
 
@@ -148,7 +148,7 @@ var serverCmd = &cobra.Command{
 
 		srv, err := baldaapi.NewServer(h, h, baldaapi.WithPathPrefix("/balda/api/v1"))
 		if err != nil {
-			return fmt.Errorf("create ogen server: %v", err)
+			return fmt.Errorf("create ogen server: %w", err)
 		}
 
 		mux := http.NewServeMux()
@@ -163,7 +163,7 @@ var serverCmd = &cobra.Command{
 		mux.Handle("/", srv)
 
 		addr := fmt.Sprintf("%s:%d", cfg.ServerAddr, cfg.ServerPort)
-		httpSrv := &http.Server{Addr: addr, Handler: mux}
+		httpSrv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 
 		go func() {
 			slog.Info("starting server", slog.String("addr", addr))

--- a/internal/game/dictionary.go
+++ b/internal/game/dictionary.go
@@ -3,10 +3,12 @@ package game
 import (
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/rustwizard/balda/internal/rnd"
 	"io"
 	"unicode/utf8"
+
+	"github.com/rustwizard/balda/internal/rnd"
 )
 
 //go:embed assets/russian_nouns_with_definition.json
@@ -35,11 +37,11 @@ func NewDictionary() (*Dictionary, error) {
 	for {
 		var words map[string]interface{}
 		err = dec.Decode(&words)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return dict, fmt.Errorf("game: dictionary: decode: %w", err)
 		}
 
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 

--- a/internal/server/restapi/handlers/auth.go
+++ b/internal/server/restapi/handlers/auth.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -31,7 +32,7 @@ func (h *Handlers) Auth(ctx context.Context, req *baldaapi.AuthRequest) (baldaap
 	}
 
 	sid, err := h.sess.Get(u.UID)
-	if err == session.ErrNotFound {
+	if errors.Is(err, session.ErrNotFound) {
 		sidStr, err := h.sess.Create(u.UID)
 		if err != nil {
 			slog.Error("auth: create sid", slog.Any("error", err))

--- a/internal/service/balda_service.go
+++ b/internal/service/balda_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -24,7 +25,7 @@ func New(lby *lobby.Lobby, mm *matchmaking.Queue, s *storage.Balda, n game.Notif
 
 func (s *Balda) GameSummary(playerID string) *lobby.GameSummary {
 	gs, err := s.lby.FindByPlayer(playerID)
-	if err == lobby.ErrGameNotFound {
+	if errors.Is(err, lobby.ErrGameNotFound) {
 		return nil
 	}
 	return &gs


### PR DESCRIPTION
- Use %w in fmt.Errorf for proper error wrapping
- Replace == / != with errors.Is for io.EOF, session.ErrNotFound, lobby.ErrGameNotFound
- Add ReadHeaderTimeout to http.Server to prevent Slowloris attack
- Remove nilerr linter (false positives on ogen handler pattern)