### PR TITLE
refactor: share single Redis client for sessions

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
 	"github.com/rustwizard/balda/api/openapi"
 	"github.com/rustwizard/balda/internal/centrifugo"
 	"github.com/rustwizard/balda/internal/game"
@@ -109,7 +110,12 @@ var serverCmd = &cobra.Command{
 		}
 		defer pool.Close()
 
-		sess := session.NewService(cfg.Session)
+		sess := session.NewService(cfg.Session, redis.NewClient(&redis.Options{
+			Addr:     cfg.Session.Addr,
+			Username: cfg.Session.Username,
+			Password: cfg.Session.Password,
+			DB:       cfg.Session.DBNum,
+		}))
 
 		cf := centrifugo.NewClient(cfg.Centrifugo.APIURL, cfg.Centrifugo.APIKey)
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -28,15 +28,10 @@ type Service struct {
 	storage *redis.Client
 }
 
-func NewService(cfg Config) *Service {
+func NewService(cfg Config, client *redis.Client) *Service {
 	return &Service{
-		cfg: cfg,
-		storage: redis.NewClient(&redis.Options{
-			Addr:     cfg.Addr,
-			Password: cfg.Password,
-			DB:       cfg.DBNum,
-			Username: cfg.Username,
-		}),
+		cfg:     cfg,
+		storage: client,
 	}
 }
 

--- a/tests/handlers_test.go
+++ b/tests/handlers_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
 	"github.com/rustwizard/balda/internal/centrifugo"
 	"github.com/rustwizard/balda/internal/game"
 	"github.com/rustwizard/balda/internal/lobby"
@@ -92,7 +93,7 @@ func setupCore(ctx context.Context, t *testing.T) *coreSetup {
 	sess := session.NewService(session.Config{
 		Addr:       redisAddr,
 		Expiration: 30 * time.Second,
-	})
+	}, redis.NewClient(&redis.Options{Addr: redisAddr}))
 
 	lby := lobby.New(func(_ context.Context, _ string, players []*game.Player, n game.Notifier) (*game.Game, error) {
 		return game.NewGameWithWord(players, "масло", n)

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,7 +18,7 @@ func TestSessionService(t *testing.T) {
 	addr, cleanup := startRedis(ctx, t)
 	defer cleanup()
 
-	svc := session.NewService(session.Config{Addr: addr, Expiration: 30 * time.Second})
+	svc := session.NewService(session.Config{Addr: addr, Expiration: 30 * time.Second}, redis.NewClient(&redis.Options{Addr: addr}))
 
 	t.Run("Save and Get", func(t *testing.T) {
 		u := &session.User{Sid: "test_sid", UID: 1000}


### PR DESCRIPTION
Create the Redis client in cmd/server.go and pass it to session.NewService as a dependency instead of creating a separate client inside the package. Eliminates the second Redis connection pool to the same instance.