### PR TITLE
feat: graceful shutdown and HTTP server timeouts

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without subcommands
 var rootCmd = &cobra.Command{
 	Use:   "balda",
 	Short: "Balda Game API Service",
@@ -19,7 +22,10 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		slog.Error("got an error when running Balda API service", slog.Any("error", err))
 		os.Exit(1)
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,10 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -159,7 +156,14 @@ var serverCmd = &cobra.Command{
 		mux.Handle("/", srv)
 
 		addr := fmt.Sprintf("%s:%d", cfg.ServerAddr, cfg.ServerPort)
-		httpSrv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+		httpSrv := &http.Server{
+			Addr:              addr,
+			Handler:           mux,
+			ReadTimeout:       30 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			IdleTimeout:       120 * time.Second,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
 
 		go func() {
 			slog.Info("starting server", slog.String("addr", addr))
@@ -168,9 +172,7 @@ var serverCmd = &cobra.Command{
 			}
 		}()
 
-		quit := make(chan os.Signal, 1)
-		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-		<-quit
+		<-cmd.Context().Done()
 
 		slog.Info("shutting down server")
 


### PR DESCRIPTION
- Replace Execute() with ExecuteContext() using signal.NotifyContext for SIGINT/SIGTERM propagation
- Add ReadTimeout, WriteTimeout, IdleTimeout to http.Server
- Use cmd.Context().Done() instead of manual signal.Notify in server
- Remove unused os/signal and syscall imports from server.go