### PR TITLE
fix(auth): remove token logging, info noise, use constant-time compare

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -79,15 +79,12 @@ WaitGroup для graceful shutdown. Комментарий в миграции `
 `PlayerForGame` (player_id + exp), `playerIDByUID` — обёртка для методов,
 где нужен только player_id.
 
-### 10. Утечка кредов в логи и шумное логирование
-**Файл:** `internal/server/restapi/handlers/handlers.go:47,51,57,61`
+### 10. ✅ Утечка кредов в логи и шумное логирование
+**Файл:** `internal/server/restapi/handlers/handlers.go:74,84`
 
-При неверном ключе в лог пишется сам токен (`slog.String("token", t.APIKey)`).
-Плюс `slog.Info("KeyAuth ... handler called")` на каждый запрос. Сравнение `t.APIKey == h.xAPIToken`
-не constant-time (теоретическая тайминг-атака).
-
-**Предложение:** не логировать значение токена, понизить уровень/убрать info-шум,
-использовать `subtle.ConstantTimeCompare`.
+Реализовано: убрано логирование значения токена (`slog.String("token", ...)`), удалён
+шумный `slog.Info("KeyAuth ... handler called")` на каждый запрос. Сравнение токенов
+заменено на `subtle.ConstantTimeCompare` для защиты от timing-атак.
 
 ### 11. Единый статический API-токен на всех пользователей
 **Файлы:** `cmd/server.go:182`, `handlers.go`

--- a/internal/server/restapi/handlers/handlers.go
+++ b/internal/server/restapi/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"log/slog"
 	"strconv"
@@ -72,20 +73,18 @@ func (h *Handlers) publishLobbyUpdate(ctx context.Context) {
 
 // HandleAPIKeyHeader implements baldaapi.SecurityHandler.
 func (h *Handlers) HandleAPIKeyHeader(ctx context.Context, _ baldaapi.OperationName, t baldaapi.APIKeyHeader) (context.Context, error) {
-	slog.Info("KeyAuth header handler called")
-	if t.APIKey == h.xAPIToken {
+	if subtle.ConstantTimeCompare([]byte(t.APIKey), []byte(h.xAPIToken)) == 1 {
 		return ctx, nil
 	}
-	slog.Error("access attempt with incorrect api key header", slog.String("token", t.APIKey))
+	slog.Error("access attempt with incorrect api key header")
 	return nil, errors.New("api key header: token error")
 }
 
 // HandleAPIKeyQueryParam implements baldaapi.SecurityHandler.
 func (h *Handlers) HandleAPIKeyQueryParam(ctx context.Context, _ baldaapi.OperationName, t baldaapi.APIKeyQueryParam) (context.Context, error) {
-	slog.Info("KeyAuth query param handler called")
-	if t.APIKey == h.xAPIToken {
+	if subtle.ConstantTimeCompare([]byte(t.APIKey), []byte(h.xAPIToken)) == 1 {
 		return ctx, nil
 	}
-	slog.Error("access attempt with incorrect api key query param", slog.String("token", t.APIKey))
+	slog.Error("access attempt with incorrect api key query param")
 	return nil, errors.New("api key param: token error")
 }


### PR DESCRIPTION
- Replace t.APIKey == h.xAPIToken with subtle.ConstantTimeCompare to prevent timing attacks
- Remove slog.String("token", ...) that leaked credentials to logs
- Remove slog.Info("KeyAuth ... handler called") on every request
- Mark IMPROVEMENTS #10 as done