### PR TITLE
feat: replace global API token with per-user api_key validation

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -80,7 +80,6 @@ type Config struct {
 	Pg         PgConfig
 	Session    session.Config
 	Presence   presence.Config
-	XAPIToken  string
 	Centrifugo CentrifugoConfig
 }
 
@@ -141,7 +140,7 @@ var serverCmd = &cobra.Command{
 
 		svc := service.New(lby, mm, s)
 
-		h := handlers.New(svc, sess, pres, cfg.XAPIToken, cf, cfg.Centrifugo.TokenHMACSecret)
+		h := handlers.New(svc, sess, pres, cf, cfg.Centrifugo.TokenHMACSecret)
 
 		srv, err := baldaapi.NewServer(h, h, baldaapi.WithPathPrefix("/balda/api/v1"))
 		if err != nil {
@@ -223,7 +222,6 @@ func (c *Config) Flags(prefix string) *pflag.FlagSet {
 	f.StringVar(&c.Pg.Password, "pg.password", "", "postgres password")
 	f.IntVar(&c.Pg.MaxPoolSize, "pg.max_pool_size", 10, "postgres max pool size")
 	f.StringVar(&c.Pg.SSL, "pg.ssl", "disable", "postgres ssl")
-	f.StringVar(&c.XAPIToken, prefix+"x_api_token", "", "x-api-token for header or query param")
 	f.StringVar(&c.Centrifugo.APIURL, "centrifugo.api_url", "http://127.0.0.1:8000/api", "centrifugo api url")
 	f.StringVar(&c.Centrifugo.APIKey, "centrifugo.api_key", "", "centrifugo api key")
 	f.StringVar(&c.Centrifugo.TokenHMACSecret, "centrifugo.token_hmac_secret_key", "", "centrifugo token hmac secret")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     environment:
       SERVER_ADDR: 0.0.0.0
       SERVER_PORT: 9666
-      SERVER_X_API_TOKEN: abcdefuvwxyz
       PG_HOST: pg
       PG_USER: balda
       PG_DATABASE: balda

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -1,0 +1,191 @@
+# Предложения по улучшению Balda
+
+Документ собран по итогам ревью кодовой базы. Пункты сгруппированы по приоритету.
+Для каждого указаны затронутые файлы, суть проблемы и предлагаемое решение.
+
+## 🔴 Критические (корректность, конкурентность, безопасность)
+
+### 1. ✅ Игра завершается естественным образом
+**Файлы:** `internal/game/fsm.go`, `internal/game/game.go`
+
+Реализовано: `EventGameFinished` заменяет `EventBoardFull` как единое событие естественного
+завершения (доска заполнена или все игроки подряд сделали skip). Победитель при любом
+естественном конце определяется по `Score` (в `gamecoord.findWinnerByScore`).
+
+Если доска заполнена — `SubmitWord` отправляет `EventGameFinished`.
+Если все игроки подряд скипают (`consecutiveSkipsTotal >= len(players)`) — `onSkip`
+отправляет `EventGameFinished` как эвристику «нет доступных ходов».
+
+### 3. ✅ Нет graceful shutdown и таймаутов HTTP-сервера
+**Файлы:** `cmd/root.go:22` (`rootCmd.Execute()`), `cmd/server.go:159` (`http.ListenAndServe`)
+
+Реализовано: `Execute()` заменён на `ExecuteContext()` с `signal.NotifyContext(SIGINT/SIGTERM)`.
+HTTP-сервер создан явно как `&http.Server{...}` с `ReadTimeout`, `WriteTimeout`, `IdleTimeout`
+и `ReadHeaderTimeout`. Сервер ожидает `<-cmd.Context().Done()` вместо ручного `signal.Notify`,
+после чего вызывается `lby.Shutdown()` (отмена контекста всех игр) и `httpSrv.Shutdown(ctx)`
+с таймаутом 30s. Дожидаются завершения `pendingResults` (сохранение результатов игр).
+
+## 🟠 Высокий приоритет (незавершённый функционал, мёртвый код)
+
+### 4. Matchmaking подключён, но не работает
+**Файлы:** `cmd/server.go:130`, `internal/service/balda_service.go:16`
+
+`matchmaking.Queue` создаётся, но `mm.Run(ctx)` нигде в проде не вызывается, и ни один хендлер
+не делает `mm.Enqueue`. В продакшене очередь — мёртвый код (используется только в тестах).
+
+**Предложение:** либо подключить (эндпоинт постановки в очередь + `go mm.Run(serverCtx)`),
+либо убрать из прод-пути до готовности фичи.
+
+### 5. ✅ `Player.Exp` не загружается из БД
+**Файлы:** `internal/service/balda_service.go:70,79`
+
+Реализовано: `CreateGame` и `JoinGame` загружают `exp` через `storage.GetPlayerByUID`
+(`SELECT player_id, COALESCE(exp, 0) FROM player_state`) и передают в `game.Player{Exp: p.Exp}`.
+Тестовые хелперы (`makePlayers` в `lobby_test`, `game_fsm_test`, `coord_test`, `list_games_test`,
+`handlers_test`) также обновлены для создания игроков с ненулевым `Exp`.
+
+### 6. ✅ Результаты игр не сохраняются
+**Файлы:** `internal/gamecoord/coord.go` (game_over), `internal/storage/game_result.go`
+
+Реализовано: `gamecoord.dispatchGameResult` вызывает `onGameOver` callback (провайдерится в
+`cmd/server.go` как `makeOnGameOverCallback`) до публикации в Centrifugo.
+`storage.SaveGameResult` в транзакции: (1) INSERT INTO `game_results`, (2) INSERT INTO
+`game_result_players` (score, words_count, exp_gained), (3) UPDATE `player_state SET exp = exp + $1`.
+Callback обёрнут в retry (3 попытки, backoff 100/200 мс) и учитывается в `pendingResults`
+WaitGroup для graceful shutdown. Комментарий в миграции `003_game_results.up.sql` обновлён
+с `'board_full'` на `'game_finished'`.
+
+### 7. ✅ Мёртвый/легаси-код в game.go
+**Файлы:** `internal/game/game.go:454` (`AddWordToCurrentPlayer`), `:460` (`IsTakenWord`)
+
+Реализовано: удалены `AddWordToCurrentPlayer` и `IsTakenWord`. Проверка дубликатов в
+`SubmitWord` оставлена как `slices.Contains` (быстро, без аллокаций). Тесты мёртвого кода
+удалены, лишние тесты на `IsTakenWord` убраны.
+
+## 🟡 Средний приоритет (надёжность, дизайн, безопасность)
+
+### 8. ✅ Гомоглиф в имени метода
+**Файл:** `internal/game/game.go:75` — `СheckWordExistence`
+
+Реализовано: кириллическая `С` (U+0421) заменена на латинскую `C` (U+0043) в методе
+`CheckWordExistence`. Исправлено в PR #102 (`fix/method-typo`).
+
+### 9. ✅ Дублирование запроса player_id + все SQL-запросы в storage-слой
+**Файлы:** `internal/service/balda_service.go`, `internal/server/restapi/handlers/auth.go`,
+`handlers/signup.go`, `handlers/player_state.go`, `internal/storage/user.go`, `internal/storage/player.go`
+
+Реализовано (ветка `refactor/storage-layer`): все SQL-запросы вынесены в storage-слой.
+- Добавлены методы `storage.AuthUser`, `storage.CreateUser` (файл `storage/user.go`).
+- Добавлены методы `storage.GetPlayerState`, `storage.GetPlayerByUID` (файл `storage/player.go`).
+- `service.Balda` лишился метода `DB()` — хендлеры больше не трогают `Pool()` напрямую.
+- Хендлеры `auth.go`, `signup.go`, `player_state.go` работают только через сервисный слой.
+- Лишний `pgx.BeginTxFunc` в `GetPlayerStateUID` (одиночный SELECT) убран.
+
+### 10. ✅ Утечка кредов в логи и шумное логирование
+**Файл:** `internal/server/restapi/handlers/handlers.go:74,84`
+
+Реализовано: убрано логирование значения токена (`slog.String("token", ...)`), удалён
+шумный `slog.Info("KeyAuth ... handler called")` на каждый запрос. Сравнение токенов
+заменено на `subtle.ConstantTimeCompare` для защиты от timing-атак.
+
+### 11. ✅ Единый статический API-токен заменён на персональные ключи
+**Файлы:** `cmd/server.go`, `internal/server/restapi/handlers/handlers.go`,
+`internal/storage/user.go`, `internal/service/balda_service.go`
+
+Реализовано (ветка `feature/per-user-api-keys`): глобальный `xAPIToken` из конфига удалён.
+`HandleAPIKeyHeader` и `HandleAPIKeyQueryParam` теперь вызывают `storage.ValidateAPIKey`,
+который проверяет, существует ли переданный UUID в колонке `api_key` таблицы `users`.
+Каждый пользователь получает свой ключ при регистрации (`POST /signup → Key`).
+Не-UUID формат быстро отклоняется без обращения к БД.
+
+### 12. Логическая ошибка в auth.go
+**Файл:** `internal/server/restapi/handlers/auth.go:27-32`
+
+Ветка `if uid == 0` после ошибки `Scan` всегда истинна (при ошибке `uid` не присваивается),
+поэтому различение «неверный пароль» и «ошибка БД» не работает. Любая ошибка возвращает 401,
+даже сбой БД (должен быть 500).
+
+**Предложение:** различать `errors.Is(err, pgx.ErrNoRows)` → 401, иначе → 500.
+
+### 13. ✅ Не проверяется минимальная длина слова (≥3)
+**Файл:** `internal/game/game.go` (`SubmitWord`)
+
+Реализовано (ветка `fix/min-word-length`): добавлен `ErrWordTooShort` и проверка
+`len(word) < 3` как первая после state/player-проверок. Тесты, использовавшие
+2-буквенные пути, обновлены до 3-буквенных.
+
+### 14. Дублирование и рассинхрон публикаций game_state
+**Файлы:** `internal/server/restapi/handlers/move_game.go:91-97`, `internal/gamecoord/coord.go:51-64`
+
+И хендлер `MoveGame`, и `gamecoord` (на `NotifyTurnStart`) публикуют `game_state` на каждый ход.
+Хендлер при этом сам «угадывает» следующего игрока (`nextPlayerID`), дублируя логику FSM, что
+может рассинхронизироваться с реальным состоянием игры (особенно при скипах/таймаутах).
+
+**Предложение:** оставить единственный источник истины публикаций (gamecoord), хендлер вернёт
+синхронный ответ без второй публикации.
+
+## 🟢 Низкий приоритет (чистота, инфраструктура, тесты)
+
+### 15. CI без линтера и без -race
+**Файл:** `.github/workflows/ci.yml`
+
+Есть `.golangci.yml`, но в CI нет шага `golangci-lint`. Тесты гоняются без `-race` (критично для
+конкурентного игрового сервера). Шаг `Install swagger` (go-swagger) выглядит устаревшим — code-gen
+использует ogen.
+
+**Предложение:** добавить `golangci-lint run`, `go test -race`, убрать ненужный go-swagger.
+
+### 16. Артефакт coverage.out в репозитории
+**Файл:** `coverage.out`
+
+Закоммичен отчёт покрытия.
+
+**Предложение:** удалить из git и добавить в `.gitignore`.
+
+### 17. Мелочи в storage
+**Файл:** `internal/storage/storage.go`
+
+Поле `t time.Duration` хранится, но не используется. `func (b Balda) Pool()` — value receiver
+копирует структуру.
+
+**Предложение:** удалить неиспользуемое поле либо реально применять таймаут; перейти на pointer receiver.
+
+### 18. centrifugo.Client без таймаута
+**Файл:** `internal/centrifugo/client.go:21`
+
+`http.Client{}` без `Timeout`; полагается только на ctx вызывающего.
+
+**Предложение:** задать дефолтный `Timeout` как страховку.
+
+### 19. Dictionary.FiveLetters — map вместо slice
+**Файл:** `internal/game/dictionary.go:17,52,62`
+
+`map[int]string` с последовательным счётчиком-ключом — фактически срез. Лишний оверхед.
+
+**Предложение:** заменить на `[]string`.
+
+### 20. Неограниченные горутины публикаций в gamecoord
+**Файл:** `internal/gamecoord/coord.go:62,63,73,81,90`
+
+Каждое событие порождает `go c.publish...`; нет ограничения количества и нет гарантий порядка
+доставки `turn_change` vs `game_state`.
+
+**Предложение:** рассмотреть последовательную публикацию (без `go`) под 3-сек ctx или единый
+канал публикаций.
+
+### 21. ✅ Аутентификация и игровое присутствие смешаны в одну сессию
+**Файлы:** `internal/session/session.go`, `internal/session/config.go`, `internal/server/restapi/handlers/ping.go`
+
+Реализовано (ветка `feature/separate-auth-presence`): авторизационная сессия (TTL 24h) и игровое
+присутствие разделены. Новый пакет `internal/presence/` ведёт ключи `presence:{uid}` в Redis с
+TTL 30s. `POST /session/ping` теперь обновляет только presence, не трогая auth-сессию.
+Фронт шлёт пинг каждые 5s — запас в 6× относительно TTL.
+
+### 22. Игровая логика не использует presence для ускоренного таймаута
+**Файлы:** `internal/gamecoord/coord.go`, `internal/lobby/lobby.go`, `cmd/server.go`
+
+При отключении игрока (presence-ключ истёк) сервер по-прежнему ждёт полных 60s таймаута хода,
+а не реагирует сразу.
+
+**Предложение:** пробросить `*presence.Service` в фабрику игр (`cmd/server.go`) и при старте
+хода запускать сокращённый grace-таймер (например, 5s) если `presence.IsOnline` вернул false.

--- a/internal/server/restapi/handlers/handlers.go
+++ b/internal/server/restapi/handlers/handlers.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"crypto/subtle"
 	"errors"
 	"log/slog"
 	"strconv"
@@ -20,13 +19,12 @@ type Handlers struct {
 	svc                       *service.Balda
 	sess                      *session.Service
 	pres                      *presence.Service
-	xAPIToken                 string
 	cf                        *centrifugo.Client
 	centrifugoTokenHMACSecret string
 }
 
-func New(svc *service.Balda, sess *session.Service, pres *presence.Service, xAPIToken string, cf *centrifugo.Client, centrifugoTokenHMACSecret string) *Handlers {
-	return &Handlers{svc: svc, sess: sess, pres: pres, xAPIToken: xAPIToken, cf: cf, centrifugoTokenHMACSecret: centrifugoTokenHMACSecret}
+func New(svc *service.Balda, sess *session.Service, pres *presence.Service, cf *centrifugo.Client, centrifugoTokenHMACSecret string) *Handlers {
+	return &Handlers{svc: svc, sess: sess, pres: pres, cf: cf, centrifugoTokenHMACSecret: centrifugoTokenHMACSecret}
 }
 
 // generateCentrifugoTokens returns a connection token and a lobby subscription token for the given user.
@@ -75,18 +73,28 @@ func (h *Handlers) publishLobbyUpdate(ctx context.Context) {
 
 // HandleAPIKeyHeader implements baldaapi.SecurityHandler.
 func (h *Handlers) HandleAPIKeyHeader(ctx context.Context, _ baldaapi.OperationName, t baldaapi.APIKeyHeader) (context.Context, error) {
-	if subtle.ConstantTimeCompare([]byte(t.APIKey), []byte(h.xAPIToken)) == 1 {
-		return ctx, nil
+	ok, err := h.svc.ValidateAPIKey(ctx, t.APIKey)
+	if err != nil {
+		slog.Error("api key header: db error", slog.Any("error", err))
+		return nil, errors.New("api key header: internal error")
 	}
-	slog.Error("access attempt with incorrect api key header")
-	return nil, errors.New("api key header: token error")
+	if !ok {
+		slog.Error("access attempt with incorrect api key header")
+		return nil, errors.New("api key header: token error")
+	}
+	return ctx, nil
 }
 
 // HandleAPIKeyQueryParam implements baldaapi.SecurityHandler.
 func (h *Handlers) HandleAPIKeyQueryParam(ctx context.Context, _ baldaapi.OperationName, t baldaapi.APIKeyQueryParam) (context.Context, error) {
-	if subtle.ConstantTimeCompare([]byte(t.APIKey), []byte(h.xAPIToken)) == 1 {
-		return ctx, nil
+	ok, err := h.svc.ValidateAPIKey(ctx, t.APIKey)
+	if err != nil {
+		slog.Error("api key query param: db error", slog.Any("error", err))
+		return nil, errors.New("api key param: internal error")
 	}
-	slog.Error("access attempt with incorrect api key query param")
-	return nil, errors.New("api key param: token error")
+	if !ok {
+		slog.Error("access attempt with incorrect api key query param")
+		return nil, errors.New("api key param: token error")
+	}
+	return ctx, nil
 }

--- a/internal/service/balda_service.go
+++ b/internal/service/balda_service.go
@@ -61,6 +61,11 @@ func (s *Balda) CreateUser(ctx context.Context, firstname, lastname, email, pass
 	return s.s.CreateUser(ctx, firstname, lastname, email, password, nickname)
 }
 
+// ValidateAPIKey reports whether the given api_key belongs to a registered user.
+func (s *Balda) ValidateAPIKey(ctx context.Context, apiKey string) (bool, error) {
+	return s.s.ValidateAPIKey(ctx, apiKey)
+}
+
 // GetPlayerState returns the profile fields for the given player UUID.
 func (s *Balda) GetPlayerState(ctx context.Context, playerID uuid.UUID) (storage.PlayerState, error) {
 	return s.s.GetPlayerState(ctx, playerID)

--- a/internal/storage/user.go
+++ b/internal/storage/user.go
@@ -41,6 +41,26 @@ func (b *Balda) AuthUser(ctx context.Context, email, password string) (UserAuth,
 	return u, nil
 }
 
+// ValidateAPIKey reports whether the given string is a valid UUID that exists
+// as an api_key in the users table. Invalid UUID format returns false without
+// hitting the database.
+func (b *Balda) ValidateAPIKey(ctx context.Context, apiKey string) (bool, error) {
+	parsed, err := uuid.Parse(apiKey)
+	if err != nil {
+		return false, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, b.t)
+	defer cancel()
+
+	var exists bool
+	if err := b.db.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM users WHERE api_key = $1)`, parsed,
+	).Scan(&exists); err != nil {
+		return false, fmt.Errorf("validate api key: %w", err)
+	}
+	return exists, nil
+}
+
 // CreateUser inserts a new user and their player_state in a single transaction.
 func (b *Balda) CreateUser(ctx context.Context, firstname, lastname, email, password, nickname string) (UserCreated, error) {
 	ctx, cancel := context.WithTimeout(ctx, b.t)

--- a/tests/create_game_test.go
+++ b/tests/create_game_test.go
@@ -66,7 +66,7 @@ func TestCreateGameHandler(t *testing.T) {
 }
 
 func TestCreateGameHTTP(t *testing.T) {
-	srv, email, password, cleanup := setupServer(t)
+	srv, email, password, apiKey, cleanup := setupServer(t)
 	defer cleanup()
 
 	gamesURL := srv.URL + "/balda/api/v1/games"
@@ -75,7 +75,7 @@ func TestCreateGameHTTP(t *testing.T) {
 		body, _ := json.Marshal(map[string]string{"email": email, "password": password})
 		req, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/auth", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		return req
 	}())
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestCreateGameHTTP(t *testing.T) {
 	t.Run("unknown session returns 401", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodPost, gamesURL, http.NoBody)
 		require.NoError(t, err)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", "unknown-sid")
 
 		resp, err := http.DefaultClient.Do(req)
@@ -116,7 +116,7 @@ func TestCreateGameHTTP(t *testing.T) {
 	t.Run("valid request creates game and returns 200", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodPost, gamesURL, http.NoBody)
 		require.NoError(t, err)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", sid)
 
 		resp, err := http.DefaultClient.Do(req)

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -68,7 +68,7 @@ func setupHandlersWithCentrifugo(ctx context.Context, t *testing.T, cfAPIURL str
 	t.Helper()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient(cfAPIURL, testCentrifugoAPIKey)
-	h := handlers.New(core.svc, core.sess, core.pres, testAPIToken, cf, testCentrifugoSecret)
+	h := handlers.New(core.svc, core.sess, core.pres, cf, testCentrifugoSecret)
 	return h, core.cleanup
 }
 
@@ -139,6 +139,7 @@ func TestCreateGame_PublishesEvGameCreated(t *testing.T) {
 	var signupResp baldaapi.SignupResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &signupResp))
 	sid := signupResp.User.Value.Sid.Value
+	apiKey := signupResp.User.Value.Key.Value
 	cfToken := signupResp.CentrifugoToken.Value
 	lobbyToken := signupResp.LobbyToken.Value
 
@@ -148,7 +149,7 @@ func TestCreateGame_PublishesEvGameCreated(t *testing.T) {
 	// create game
 	w = httptest.NewRecorder()
 	req := newReq(t, http.MethodPost, "/balda/api/v1/games", nil)
-	req.Header.Set("X-API-Key", testAPIToken)
+	req.Header.Set("X-API-Key", apiKey)
 	req.Header.Set("X-API-Session", sid)
 	srv.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
@@ -179,13 +180,13 @@ func TestJoinGame_PublishesEvGameStarted(t *testing.T) {
 	require.NoError(t, err)
 
 	// signup player 1 and player 2
-	p1Sid, p1CfToken, p1LobbyToken := signupPlayer(t, srv, "player1@test.com")
-	p2Sid, _, _ := signupPlayer(t, srv, "player2@test.com")
+	p1Sid, p1CfToken, p1LobbyToken, p1APIKey := signupPlayer(t, srv, "player1@test.com")
+	p2Sid, _, _, _ := signupPlayer(t, srv, "player2@test.com")
 
 	// player 1 creates a game
 	w := httptest.NewRecorder()
 	req := newReq(t, http.MethodPost, "/balda/api/v1/games", nil)
-	req.Header.Set("X-API-Key", testAPIToken)
+	req.Header.Set("X-API-Key", p1APIKey)
 	req.Header.Set("X-API-Session", p1Sid)
 	srv.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
@@ -202,7 +203,7 @@ func TestJoinGame_PublishesEvGameStarted(t *testing.T) {
 	// player 2 joins
 	w = httptest.NewRecorder()
 	req = newReq(t, http.MethodPost, "/balda/api/v1/games/"+gameID+"/join", nil)
-	req.Header.Set("X-API-Key", testAPIToken)
+	req.Header.Set("X-API-Key", p1APIKey)
 	req.Header.Set("X-API-Session", p2Sid)
 	srv.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
@@ -232,7 +233,7 @@ func TestJoinGame_PublishesEvGameStarted(t *testing.T) {
 	}
 }
 
-func signupPlayer(t *testing.T, srv http.Handler, email string) (sid, cfToken, lobbyToken string) {
+func signupPlayer(t *testing.T, srv http.Handler, email string) (sid, cfToken, lobbyToken, apiKey string) {
 	t.Helper()
 	body, _ := json.Marshal(map[string]string{
 		"firstname": "Test", "lastname": "Player",
@@ -244,7 +245,7 @@ func signupPlayer(t *testing.T, srv http.Handler, email string) (sid, cfToken, l
 
 	var resp baldaapi.SignupResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	return resp.User.Value.Sid.Value, resp.CentrifugoToken.Value, resp.LobbyToken.Value
+	return resp.User.Value.Sid.Value, resp.CentrifugoToken.Value, resp.LobbyToken.Value, resp.User.Value.Key.Value
 }
 
 func newReq(t *testing.T, method, path string, body []byte) *http.Request {

--- a/tests/handlers_test.go
+++ b/tests/handlers_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-const testAPIToken = "test-api-token"
 
 func startRedis(ctx context.Context, t *testing.T) (addr string, cleanup func()) {
 	t.Helper()
@@ -128,7 +127,7 @@ func setupHandlers(t *testing.T) (*handlers.Handlers, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.sess, core.pres, testAPIToken, cf, "test-secret")
+	h := handlers.New(core.svc, core.sess, core.pres, cf, "test-secret")
 	return h, core.cleanup
 }
 
@@ -347,7 +346,7 @@ func setupFull(t *testing.T) (*handlers.Handlers, *lobby.Lobby, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.sess, core.pres, testAPIToken, cf, "test-secret")
+	h := handlers.New(core.svc, core.sess, core.pres, cf, "test-secret")
 	return h, core.lby, core.cleanup
 }
 
@@ -483,7 +482,7 @@ func TestPingHandler(t *testing.T) {
 }
 
 func TestPingHTTP(t *testing.T) {
-	srv, email, password, cleanup := setupServer(t)
+	srv, email, password, apiKey, cleanup := setupServer(t)
 	defer cleanup()
 
 	// Auth to get the session SID.
@@ -491,7 +490,7 @@ func TestPingHTTP(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/auth", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-API-Key", testAPIToken)
+	req.Header.Set("X-API-Key", apiKey)
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -525,7 +524,7 @@ func TestPingHTTP(t *testing.T) {
 	t.Run("unknown sid returns 401", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodPost, pingURL, http.NoBody)
 		require.NoError(t, err)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-Request-ID", "1")
 		req.Header.Set("X-API-Session", "unknown-sid")
 
@@ -538,7 +537,7 @@ func TestPingHTTP(t *testing.T) {
 	t.Run("valid session returns 204 with response headers", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodPost, pingURL, http.NoBody)
 		require.NoError(t, err)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-Request-ID", "42")
 		req.Header.Set("X-API-Session", sid)
 
@@ -554,7 +553,8 @@ func TestPingHTTP(t *testing.T) {
 
 // setupServer returns an httptest.Server wired with a full ogen server
 // (including security middleware) plus a seeded user for auth requests.
-func setupServer(t *testing.T) (srv *httptest.Server, email, password string, cleanup func()) {
+// apiKey is the per-user UUID that must be sent as X-API-Key on protected endpoints.
+func setupServer(t *testing.T) (srv *httptest.Server, email, password, apiKey string, cleanup func()) {
 	t.Helper()
 	h, cleanupHandlers := setupHandlers(t)
 
@@ -566,19 +566,22 @@ func setupServer(t *testing.T) (srv *httptest.Server, email, password string, cl
 	// Seed a user so auth requests have a valid target.
 	email, password = "sec.user@example.org", "secpass"
 	ctx := context.Background()
-	_, err = h.Signup(ctx, &baldaapi.SignupRequest{
+	res, err := h.Signup(ctx, &baldaapi.SignupRequest{
 		Firstname: "Sec",
 		Lastname:  "User",
 		Email:     email,
 		Password:  password,
 	})
 	require.NoError(t, err)
+	signupRes, ok := res.(*baldaapi.SignupResponse)
+	require.True(t, ok)
+	apiKey = signupRes.User.Value.Key.Value
 
 	cleanup = func() {
 		srv.Close()
 		cleanupHandlers()
 	}
-	return srv, email, password, cleanup
+	return srv, email, password, apiKey, cleanup
 }
 
 // postSignup signs up a new user via HTTP and returns their session ID.
@@ -620,7 +623,7 @@ func postAuth(t *testing.T, srv *httptest.Server, email, password string) *http.
 }
 
 func TestSecurityHandlers(t *testing.T) {
-	srv, email, password, cleanup := setupServer(t)
+	srv, email, password, apiKey, cleanup := setupServer(t)
 	defer cleanup()
 
 	t.Run("HandleAPIKeyHeader: valid key returns 200", func(t *testing.T) {
@@ -629,7 +632,7 @@ func TestSecurityHandlers(t *testing.T) {
 			bytes.NewReader(body))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -654,7 +657,7 @@ func TestSecurityHandlers(t *testing.T) {
 	t.Run("HandleAPIKeyQueryParam: valid key returns 200", func(t *testing.T) {
 		body, _ := json.Marshal(map[string]string{"email": email, "password": password})
 		req, err := http.NewRequest(http.MethodPost,
-			srv.URL+"/balda/api/v1/auth?api_key="+testAPIToken,
+			srv.URL+"/balda/api/v1/auth?api_key="+apiKey,
 			bytes.NewReader(body))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")

--- a/tests/join_game_test.go
+++ b/tests/join_game_test.go
@@ -108,14 +108,14 @@ func TestJoinGameHandler(t *testing.T) {
 }
 
 func TestJoinGameHTTP(t *testing.T) {
-	srv, email, password, cleanup := setupServer(t)
+	srv, email, password, apiKey, cleanup := setupServer(t)
 	defer cleanup()
 
 	// Auth the pre-seeded creator (X-API-Key is required).
 	authBody, _ := json.Marshal(map[string]string{"email": email, "password": password})
 	authReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/auth", bytes.NewReader(authBody))
 	authReq.Header.Set("Content-Type", "application/json")
-	authReq.Header.Set("X-API-Key", testAPIToken)
+	authReq.Header.Set("X-API-Key", apiKey)
 	resp, err := http.DefaultClient.Do(authReq)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -131,7 +131,7 @@ func TestJoinGameHTTP(t *testing.T) {
 
 	// Creator creates a waiting game.
 	createReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/games", http.NoBody)
-	createReq.Header.Set("X-API-Key", testAPIToken)
+	createReq.Header.Set("X-API-Key", apiKey)
 	createReq.Header.Set("X-API-Session", creatorSid)
 	createResp, err := http.DefaultClient.Do(createReq)
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestJoinGameHTTP(t *testing.T) {
 
 	t.Run("unknown session returns 401", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodPost, joinURL, http.NoBody)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", "bad-sid")
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestJoinGameHTTP(t *testing.T) {
 	t.Run("unknown game id returns 404", func(t *testing.T) {
 		url := fmt.Sprintf("%s/balda/api/v1/games/%s/join", srv.URL, uuid.New())
 		req, _ := http.NewRequest(http.MethodPost, url, http.NoBody)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", joinerSid)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -180,7 +180,7 @@ func TestJoinGameHTTP(t *testing.T) {
 
 	t.Run("valid join returns 200 with in_progress status", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodPost, joinURL, http.NoBody)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", joinerSid)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)

--- a/tests/list_games_test.go
+++ b/tests/list_games_test.go
@@ -82,7 +82,7 @@ func TestListGamesHandler(t *testing.T) {
 }
 
 func TestListGamesHTTP(t *testing.T) {
-	srv, email, password, cleanup := setupServer(t)
+	srv, email, password, apiKey, cleanup := setupServer(t)
 	defer cleanup()
 
 	gamesURL := srv.URL + "/balda/api/v1/games"
@@ -92,7 +92,7 @@ func TestListGamesHTTP(t *testing.T) {
 		body, _ := json.Marshal(map[string]string{"email": email, "password": password})
 		req, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/auth", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		return req
 	}())
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestListGamesHTTP(t *testing.T) {
 	t.Run("valid api key returns 200 with games array", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, gamesURL, http.NoBody)
 		require.NoError(t, err)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", sid)
 
 		resp, err := http.DefaultClient.Do(req)

--- a/tests/move_game_test.go
+++ b/tests/move_game_test.go
@@ -236,14 +236,14 @@ func TestSkipGameHandler(t *testing.T) {
 }
 
 func TestMoveGameHTTP(t *testing.T) {
-	srv, email, password, cleanup := setupServer(t)
+	srv, email, password, apiKey, cleanup := setupServer(t)
 	defer cleanup()
 
 	// Auth creator
 	authBody, _ := json.Marshal(map[string]string{"email": email, "password": password})
 	authReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/auth", bytes.NewReader(authBody))
 	authReq.Header.Set("Content-Type", "application/json")
-	authReq.Header.Set("X-API-Key", testAPIToken)
+	authReq.Header.Set("X-API-Key", apiKey)
 	resp, err := http.DefaultClient.Do(authReq)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -259,7 +259,7 @@ func TestMoveGameHTTP(t *testing.T) {
 
 	// Create game
 	createReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/games", http.NoBody)
-	createReq.Header.Set("X-API-Key", testAPIToken)
+	createReq.Header.Set("X-API-Key", apiKey)
 	createReq.Header.Set("X-API-Session", creatorSid)
 	createResp, err := http.DefaultClient.Do(createReq)
 	require.NoError(t, err)
@@ -275,7 +275,7 @@ func TestMoveGameHTTP(t *testing.T) {
 
 	// Join game
 	joinReq, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/balda/api/v1/games/%s/join", srv.URL, gameID), http.NoBody)
-	joinReq.Header.Set("X-API-Key", testAPIToken)
+	joinReq.Header.Set("X-API-Key", apiKey)
 	joinReq.Header.Set("X-API-Session", joinerSid)
 	joinResp, err := http.DefaultClient.Do(joinReq)
 	require.NoError(t, err)
@@ -305,7 +305,7 @@ func TestMoveGameHTTP(t *testing.T) {
 		})
 		req, _ := http.NewRequest(http.MethodPost, moveURL, bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", "bad-sid")
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -320,7 +320,7 @@ func TestMoveGameHTTP(t *testing.T) {
 		})
 		req, _ := http.NewRequest(http.MethodPost, moveURL, bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", creatorSid)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -336,13 +336,13 @@ func TestMoveGameHTTP(t *testing.T) {
 }
 
 func TestSkipGameHTTP(t *testing.T) {
-	srv, email, password, cleanup := setupServer(t)
+	srv, email, password, apiKey, cleanup := setupServer(t)
 	defer cleanup()
 
 	authBody, _ := json.Marshal(map[string]string{"email": email, "password": password})
 	authReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/auth", bytes.NewReader(authBody))
 	authReq.Header.Set("Content-Type", "application/json")
-	authReq.Header.Set("X-API-Key", testAPIToken)
+	authReq.Header.Set("X-API-Key", apiKey)
 	resp, err := http.DefaultClient.Do(authReq)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -357,7 +357,7 @@ func TestSkipGameHTTP(t *testing.T) {
 	joinerSid := postSignup(t, srv, "http.skipjoiner@example.org", "pass")
 
 	createReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/games", http.NoBody)
-	createReq.Header.Set("X-API-Key", testAPIToken)
+	createReq.Header.Set("X-API-Key", apiKey)
 	createReq.Header.Set("X-API-Session", creatorSid)
 	createResp, err := http.DefaultClient.Do(createReq)
 	require.NoError(t, err)
@@ -372,7 +372,7 @@ func TestSkipGameHTTP(t *testing.T) {
 	gameID := createBody.Game.ID
 
 	joinReq, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/balda/api/v1/games/%s/join", srv.URL, gameID), http.NoBody)
-	joinReq.Header.Set("X-API-Key", testAPIToken)
+	joinReq.Header.Set("X-API-Key", apiKey)
 	joinReq.Header.Set("X-API-Session", joinerSid)
 	joinResp, err := http.DefaultClient.Do(joinReq)
 	require.NoError(t, err)
@@ -383,7 +383,7 @@ func TestSkipGameHTTP(t *testing.T) {
 
 	t.Run("valid skip returns 204", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodPost, skipURL, http.NoBody)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", creatorSid)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -394,7 +394,7 @@ func TestSkipGameHTTP(t *testing.T) {
 	t.Run("wrong turn returns 409", func(t *testing.T) {
 		// After creator skipped, it's joiner's turn. Creator tries to skip again.
 		req, _ := http.NewRequest(http.MethodPost, skipURL, http.NoBody)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", creatorSid)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)

--- a/tests/propose_end_game_test.go
+++ b/tests/propose_end_game_test.go
@@ -200,13 +200,13 @@ func TestRejectEndGameHandler(t *testing.T) {
 }
 
 func TestProposeEndGameHTTP(t *testing.T) {
-	srv, email, password, cleanup := setupServer(t)
+	srv, email, password, apiKey, cleanup := setupServer(t)
 	defer cleanup()
 
 	authBody, _ := json.Marshal(map[string]string{"email": email, "password": password})
 	authReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/auth", bytes.NewReader(authBody))
 	authReq.Header.Set("Content-Type", "application/json")
-	authReq.Header.Set("X-API-Key", testAPIToken)
+	authReq.Header.Set("X-API-Key", apiKey)
 	authResp, err := http.DefaultClient.Do(authReq)
 	require.NoError(t, err)
 	defer authResp.Body.Close()
@@ -221,7 +221,7 @@ func TestProposeEndGameHTTP(t *testing.T) {
 	joinerSid := postSignup(t, srv, "http.propose.joiner@example.org", "pass")
 
 	createReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/balda/api/v1/games", http.NoBody)
-	createReq.Header.Set("X-API-Key", testAPIToken)
+	createReq.Header.Set("X-API-Key", apiKey)
 	createReq.Header.Set("X-API-Session", creatorSid)
 	createResp, err := http.DefaultClient.Do(createReq)
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestProposeEndGameHTTP(t *testing.T) {
 	gameID := createBody.Game.ID
 
 	joinReq, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/balda/api/v1/games/%s/join", srv.URL, gameID), http.NoBody)
-	joinReq.Header.Set("X-API-Key", testAPIToken)
+	joinReq.Header.Set("X-API-Key", apiKey)
 	joinReq.Header.Set("X-API-Session", joinerSid)
 	joinResp, err := http.DefaultClient.Do(joinReq)
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestProposeEndGameHTTP(t *testing.T) {
 
 	t.Run("wrong turn returns 409", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodPost, proposeURL, http.NoBody)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", joinerSid)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestProposeEndGameHTTP(t *testing.T) {
 
 	t.Run("valid propose returns 204", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodPost, proposeURL, http.NoBody)
-		req.Header.Set("X-API-Key", testAPIToken)
+		req.Header.Set("X-API-Key", apiKey)
 		req.Header.Set("X-API-Session", creatorSid)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)


### PR DESCRIPTION
Each user's UUID api_key (generated at signup, stored in users.api_key) is now validated against the DB in HandleAPIKeyHeader/QueryParam. Removes the shared xAPIToken config flag and SERVER_X_API_TOKEN env var.