### PR TITLE
fix: stop duplicate game_state publishes from move/skip handlers

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -114,15 +114,16 @@ _Все критические задачи решены._
 
 ## 🟡 Средний приоритет (надёжность, дизайн, безопасность)
 
-### 14. Дублирование и рассинхрон публикаций game_state
-**Файлы:** `internal/server/restapi/handlers/move_game.go`, `internal/gamecoord/coord.go`
+### 14. ✅ Дублирование и рассинхрон публикаций game_state
+**Файлы:** `internal/server/restapi/handlers/move_game.go`, `internal/server/restapi/handlers/skip_game.go`
 
-И хендлер `MoveGame`, и `gamecoord` (на `NotifyTurnStart`) публикуют `game_state` на каждый ход.
-Хендлер при этом сам «угадывает» следующего игрока (`nextPlayerID`), дублируя логику FSM, что
-может рассинхронизироваться с реальным состоянием игры (особенно при скипах/таймаутах).
+И `MoveGame`, и `SkipGame` публиковали `game_state` с «угаданным» `nextPlayerID`, дублируя то,
+что `gamecoord` публикует на `NotifyTurnStart`, и рискуя рассинхроном с FSM.
 
-**Предложение:** оставить единственный источник истины публикаций (gamecoord), хендлер вернёт
-синхронный ответ без второй публикации.
+**Сделано:** обе хендлер-публикации `game_state` удалены — единственный источник истины теперь
+`gamecoord` (`turn_change` + `game_state` на старте хода). `MoveGame` по-прежнему возвращает
+синхронный HTTP-ответ с доской и `current_turn_uid` как оптимистичным хинтом для мовера (не
+бродкаст); `SkipGame` просто отдаёт 204. Удалён осиротевший `buildGameState`.
 
 ---
 

--- a/internal/server/restapi/handlers/move_game.go
+++ b/internal/server/restapi/handlers/move_game.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/rustwizard/balda/internal/centrifugo"
 	"github.com/rustwizard/balda/internal/game"
 	"github.com/rustwizard/balda/internal/lobby"
 	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
@@ -98,16 +97,11 @@ func (h *Handlers) MoveGame(ctx context.Context, req *baldaapi.MoveRequest, para
 		}, nil
 	}
 
-	// The game's FSM processes the turn advance asynchronously.
-	// Compute the next player deterministically so the response matches the
-	// eventual server state even if the FSM hasn't advanced yet.
+	// The game's FSM processes the turn advance asynchronously and gamecoord
+	// publishes the authoritative game_state on NotifyTurnStart (single source
+	// of truth). Here we only compute the next player as an optimistic hint for
+	// the mover's synchronous response — no second publish.
 	nextTurnUID := nextPlayerID(moverID, scores)
-
-	// Publish updated game state to the game channel.
-	gameState := buildGameState(rec, nextTurnUID)
-	if err := h.cf.Publish(ctx, centrifugo.ChannelGame(rec.ID), gameState); err != nil {
-		slog.Error("move_game: publish game state", slog.Any("error", err))
-	}
 
 	nextUID, err := uuid.Parse(nextTurnUID)
 	if err != nil {
@@ -160,22 +154,3 @@ func nextPlayerID(moverID string, players []game.PlayerState) string {
 	return ""
 }
 
-func buildGameState(rec *lobby.GameRecord, currentTurnUID string) centrifugo.EvGameState {
-	scores := rec.Game.PlayerScores()
-	players := make([]centrifugo.PlayerState, 0, len(scores))
-	for _, s := range scores {
-		players = append(players, centrifugo.PlayerState{UID: s.UID, Exp: s.Exp, Score: s.Score, WordsCount: s.WordsCount, Words: s.Words})
-	}
-	if currentTurnUID == "" {
-		currentTurnUID = rec.Game.CurrentPlayerID()
-	}
-	return centrifugo.EvGameState{
-		Type:           "game_state",
-		GameID:         rec.ID,
-		Board:          rec.Game.BoardSnapshot(),
-		CurrentTurnUID: currentTurnUID,
-		Players:        players,
-		Status:         centrifugo.GameStatusInProgress,
-		MoveNumber:     rec.Game.MoveNumber(),
-	}
-}

--- a/internal/server/restapi/handlers/skip_game.go
+++ b/internal/server/restapi/handlers/skip_game.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/rustwizard/balda/internal/centrifugo"
 	"github.com/rustwizard/balda/internal/game"
 	"github.com/rustwizard/balda/internal/lobby"
 	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
@@ -24,7 +23,7 @@ func (h *Handlers) SkipGame(ctx context.Context, params baldaapi.SkipGameParams)
 		}, nil
 	}
 
-	rec, moverID, err := h.svc.SkipTurn(ctx, uid, params.ID.String())
+	_, _, err := h.svc.SkipTurn(ctx, uid, params.ID.String())
 	if err != nil {
 		switch {
 		case errors.Is(err, lobby.ErrGameNotFound):
@@ -55,11 +54,8 @@ func (h *Handlers) SkipGame(ctx context.Context, params baldaapi.SkipGameParams)
 		}
 	}
 
-	nextTurnUID := nextPlayerID(moverID, rec.Game.PlayerScores())
-	gameState := buildGameState(rec, nextTurnUID)
-	if err := h.cf.Publish(ctx, centrifugo.ChannelGame(rec.ID), gameState); err != nil {
-		slog.Error("skip_game: publish game state", slog.Any("error", err))
-	}
-
+	// gamecoord publishes the authoritative turn_change + game_state on the
+	// FSM's NotifyTurnStart after the skip advances the turn (single source of
+	// truth); the handler only acknowledges.
 	return &baldaapi.SkipGameNoContent{}, nil
 }


### PR DESCRIPTION
MoveGame and SkipGame published a guessed game_state, duplicating gamecoord's authoritative publish on NotifyTurnStart and risking FSM desync. Drop both handler publishes (and the orphaned buildGameState); gamecoord is the single source of truth. MoveGame keeps its synchronous response with an optimistic current_turn_uid hint; SkipGame returns 204.