### PR TITLE
feat: add leaderboard endpoint (p.29 IMPROVEMENTS)

### DIFF
--- a/api/openapi/http-api.yaml
+++ b/api/openapi/http-api.yaml
@@ -1,1130 +1,1233 @@
 openapi: "3.0.3"
 info:
-    title: Balda GameServer
-    description: |
-        Balda GameServer API methods and models
+  title: Balda GameServer
+  description: |
+    Balda GameServer API methods and models
 
-        ### Headers
-        | Header | Description |
-        |--------|-------------|
-        | **Authorization** | `Bearer <access_token>` — JWT access token obtained from /auth or /signup. |
-        | **X-Request-ID** | Monotonically increasing client sequence number (for /session/ping). |
-    version: 1.0.0
+    ### Headers
+    | Header | Description |
+    |--------|-------------|
+    | **Authorization** | `Bearer <access_token>` — JWT access token obtained from /auth or /signup. |
+    | **X-Request-ID** | Monotonically increasing client sequence number (for /session/ping). |
+  version: 1.0.0
 
 servers:
-    - url: http://127.0.0.1:9666/balda/api/v1
+  - url: http://127.0.0.1:9666/balda/api/v1
 
 paths:
-    /signup:
-        post:
-            operationId: signup
-            summary: Sign-up request
-            tags:
-                - Signup
-            requestBody:
-                required: true
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/SignupRequest"
-            responses:
-                "200":
-                    description: Response for signup request
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/SignupResponse"
-                "400":
-                    description: Error when signup
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
+  /signup:
+    post:
+      operationId: signup
+      summary: Sign-up request
+      tags:
+        - Signup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignupRequest"
+      responses:
+        "200":
+          description: Response for signup request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignupResponse"
+        "400":
+          description: Error when signup
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-    /auth:
-        post:
-            operationId: auth
-            summary: Auth request
-            tags:
-                - Auth
-            requestBody:
-                required: true
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/AuthRequest"
-            responses:
-                "200":
-                    description: Response for auth request
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/AuthResponse"
-                "401":
-                    description: Error when auth
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
+  /auth:
+    post:
+      operationId: auth
+      summary: Auth request
+      tags:
+        - Auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthRequest"
+      responses:
+        "200":
+          description: Response for auth request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+        "401":
+          description: Error when auth
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-    /auth/refresh:
-        post:
-            operationId: refreshToken
-            summary: Exchange a refresh token for a new access/refresh pair
-            tags:
-                - Auth
-            requestBody:
-                required: true
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/RefreshRequest"
-            responses:
-                "200":
-                    description: New token pair
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/RefreshResponse"
-                "401":
-                    description: Refresh token expired, revoked, or unknown
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
+  /auth/refresh:
+    post:
+      operationId: refreshToken
+      summary: Exchange a refresh token for a new access/refresh pair
+      tags:
+        - Auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RefreshRequest"
+      responses:
+        "200":
+          description: New token pair
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RefreshResponse"
+        "401":
+          description: Refresh token expired, revoked, or unknown
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-    /auth/logout:
-        post:
-            operationId: logout
-            summary: Revoke the current refresh token
-            tags:
-                - Auth
-            security:
-                - BearerAuth: []
-            requestBody:
-                required: false
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/LogoutRequest"
-            responses:
-                "204":
-                    description: Logged out; refresh token revoked.
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
+  /auth/logout:
+    post:
+      operationId: logout
+      summary: Revoke the current refresh token
+      tags:
+        - Auth
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LogoutRequest"
+      responses:
+        "204":
+          description: Logged out; refresh token revoked.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
-    /session/ping:
-        post:
-            operationId: ping
-            tags: [Session]
-            summary: Keepalive ping
-            description: |
-                POST not GET — mutates session TTL.
-                Returns 204 with X-Server-Time header instead of a JSON body
-                to minimize bandwidth on frequent pings (every ping_delay ms).
-            security:
-                - BearerAuth: []
-            parameters:
-                - $ref: "#/components/parameters/RequestIdHeader"
-            responses:
-                "204":
-                    description: Session alive.
-                    headers:
-                        X-Server-Time:
-                            $ref: "#/components/headers/X-Server-Time"
-                        X-Request-ID:
-                            $ref: "#/components/headers/X-Request-ID"
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
+  /session/ping:
+    post:
+      operationId: ping
+      tags: [Session]
+      summary: Keepalive ping
+      description: |
+        POST not GET — mutates session TTL.
+        Returns 204 with X-Server-Time header instead of a JSON body
+        to minimize bandwidth on frequent pings (every ping_delay ms).
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
+      responses:
+        "204":
+          description: Session alive.
+          headers:
+            X-Server-Time:
+              $ref: "#/components/headers/X-Server-Time"
+            X-Request-ID:
+              $ref: "#/components/headers/X-Request-ID"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
-    /games:
-        post:
-            operationId: createGame
-            summary: Create a new game
-            tags:
-                - Games
-            security:
-                - BearerAuth: []
-            responses:
-                "200":
-                    description: Game created successfully
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/CreateGameResponse"
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
-        get:
-            operationId: listGames
-            summary: List active games
-            description: Returns a snapshot of all currently active games.
-            tags:
-                - Games
-            security:
-                - BearerAuth: []
-            responses:
-                "200":
-                    description: List of active games
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ListGamesResponse"
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
+  /leaderboard:
+    get:
+      operationId: getLeaderboard
+      summary: Get weekly or monthly leaderboard
+      description: |
+        Returns the top players by current rating or total EXP who were active
+        during the requested period. Results are cached for 5 minutes.
+      tags:
+        - Leaderboard
+      parameters:
+        - name: period
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [week, month]
+          description: Leaderboard period
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [rating, exp]
+            default: rating
+          description: Sort field
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 100
+          description: Maximum number of entries to return
+      responses:
+        "200":
+          description: Leaderboard
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LeaderboardResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
-    /games/with-bot:
-        post:
-            operationId: createGameWithBot
-            summary: Create and start a game against a bot
-            description: |
-                Creates a new game where the authenticated player plays against a server-side bot.
-                The game starts immediately and the first move belongs to the human player.
-            tags:
-                - Games
-            security:
-                - BearerAuth: []
-            responses:
-                "200":
-                    description: Game against bot created and started successfully
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/JoinGameResponse"
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
-                "409":
-                    description: Player already in a game
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "500":
-                    $ref: "#/components/responses/InternalServerError"
+  /games:
+    post:
+      operationId: createGame
+      summary: Create a new game
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Game created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateGameResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    get:
+      operationId: listGames
+      summary: List active games
+      description: Returns a snapshot of all currently active games.
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: List of active games
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListGamesResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
-    /games/{id}/join:
-        post:
-            operationId: joinGame
-            summary: Join an existing waiting game
-            description: |
-                Adds the authenticated player to the specified waiting game.
-                When the second player joins (quorum of 2 is reached) the game
-                transitions to in_progress and the first move belongs to the
-                player who created the game.
-            tags:
-                - Games
-            security:
-                - BearerAuth: []
-            parameters:
-                - name: id
-                  in: path
-                  required: true
-                  schema:
-                      type: string
-                      format: uuid
-                  description: ID of the game to join
-            responses:
-                "200":
-                    description: Successfully joined; game is now in_progress
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/JoinGameResponse"
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
-                "404":
-                    description: Game not found
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "409":
-                    description: Cannot join (player already in a game, game not waiting, or game is full)
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "500":
-                    $ref: "#/components/responses/InternalServerError"
+  /games/with-bot:
+    post:
+      operationId: createGameWithBot
+      summary: Create and start a game against a bot
+      description: |
+        Creates a new game where the authenticated player plays against a server-side bot.
+        The game starts immediately and the first move belongs to the human player.
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Game against bot created and started successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JoinGameResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: Player already in a game
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
-    /games/{id}/move:
-        post:
-            operationId: moveGame
-            summary: Submit a move
-            description: |
-                Places a new letter on the board and submits a word. If the word is valid,
-                the player's score is updated and the turn passes to the opponent.
-            tags:
-                - Games
-            security:
-                - BearerAuth: []
-            parameters:
-                - name: id
-                  in: path
-                  required: true
-                  schema:
-                      type: string
-                      format: uuid
-                  description: ID of the game
-            requestBody:
-                required: true
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/MoveRequest"
-            responses:
-                "200":
-                    description: Move accepted
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/MoveResponse"
-                "400":
-                    description: Invalid move (bad word placement, word not in dictionary, etc.)
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
-                "403":
-                    $ref: "#/components/responses/Forbidden"
-                "404":
-                    description: Game not found
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "409":
-                    description: Not the player's turn or game not in progress
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "500":
-                    $ref: "#/components/responses/InternalServerError"
+  /games/{id}/join:
+    post:
+      operationId: joinGame
+      summary: Join an existing waiting game
+      description: |
+        Adds the authenticated player to the specified waiting game.
+        When the second player joins (quorum of 2 is reached) the game
+        transitions to in_progress and the first move belongs to the
+        player who created the game.
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the game to join
+      responses:
+        "200":
+          description: Successfully joined; game is now in_progress
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JoinGameResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Game not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Cannot join (player already in a game, game not waiting, or game is full)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
-    /games/{id}/propose-end:
-        post:
-            operationId: proposeEndGame
-            summary: Propose to end the game
-            description: |
-                The current player proposes to end the game (e.g. no valid moves are available).
-                The turn timer is paused until the opponent responds.
-                Only the player whose turn it currently is may call this.
-            tags:
-                - Games
-            security:
-                - BearerAuth: []
-            parameters:
-                - name: id
-                  in: path
-                  required: true
-                  schema:
-                      type: string
-                      format: uuid
-                  description: ID of the game
-            responses:
-                "204":
-                    description: Proposal sent successfully; waiting for opponent's response
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
-                "403":
-                    $ref: "#/components/responses/Forbidden"
-                "404":
-                    description: Game not found
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "409":
-                    description: Not the player's turn, game not in progress, or proposal already pending
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
+  /games/{id}/move:
+    post:
+      operationId: moveGame
+      summary: Submit a move
+      description: |
+        Places a new letter on the board and submits a word. If the word is valid,
+        the player's score is updated and the turn passes to the opponent.
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the game
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveRequest"
+      responses:
+        "200":
+          description: Move accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MoveResponse"
+        "400":
+          description: Invalid move (bad word placement, word not in dictionary, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Game not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Not the player's turn or game not in progress
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
-    /games/{id}/accept-end:
-        post:
-            operationId: acceptEndGame
-            summary: Accept the opponent's end-game proposal
-            description: |
-                The opponent accepts the end-game proposal. The game ends immediately with
-                the current scores. Only the non-proposing player may call this.
-            tags:
-                - Games
-            security:
-                - BearerAuth: []
-            parameters:
-                - name: id
-                  in: path
-                  required: true
-                  schema:
-                      type: string
-                      format: uuid
-                  description: ID of the game
-            responses:
-                "204":
-                    description: Proposal accepted; game is now over
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
-                "403":
-                    $ref: "#/components/responses/Forbidden"
-                "404":
-                    description: Game not found
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "409":
-                    description: No end proposal is pending or player is not the opponent
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
+  /games/{id}/propose-end:
+    post:
+      operationId: proposeEndGame
+      summary: Propose to end the game
+      description: |
+        The current player proposes to end the game (e.g. no valid moves are available).
+        The turn timer is paused until the opponent responds.
+        Only the player whose turn it currently is may call this.
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the game
+      responses:
+        "204":
+          description: Proposal sent successfully; waiting for opponent's response
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Game not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Not the player's turn, game not in progress, or proposal already pending
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-    /games/{id}/reject-end:
-        post:
-            operationId: rejectEndGame
-            summary: Reject the opponent's end-game proposal
-            description: |
-                The opponent rejects the end-game proposal. The game resumes with the
-                remaining turn time (minimum 10 seconds). Only the non-proposing player may call this.
-            tags:
-                - Games
-            security:
-                - BearerAuth: []
-            parameters:
-                - name: id
-                  in: path
-                  required: true
-                  schema:
-                      type: string
-                      format: uuid
-                  description: ID of the game
-            responses:
-                "204":
-                    description: Proposal rejected; game continues
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
-                "403":
-                    $ref: "#/components/responses/Forbidden"
-                "404":
-                    description: Game not found
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "409":
-                    description: No end proposal is pending or player is not the opponent
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
+  /games/{id}/accept-end:
+    post:
+      operationId: acceptEndGame
+      summary: Accept the opponent's end-game proposal
+      description: |
+        The opponent accepts the end-game proposal. The game ends immediately with
+        the current scores. Only the non-proposing player may call this.
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the game
+      responses:
+        "204":
+          description: Proposal accepted; game is now over
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Game not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: No end proposal is pending or player is not the opponent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-    /games/{id}/skip:
-        post:
-            operationId: skipGame
-            summary: Skip turn
-            description: |
-                Ends the current turn without making a move. The turn passes to the opponent.
-            tags:
-                - Games
-            security:
-                - BearerAuth: []
-            parameters:
-                - name: id
-                  in: path
-                  required: true
-                  schema:
-                      type: string
-                      format: uuid
-                  description: ID of the game
-            responses:
-                "204":
-                    description: Turn skipped successfully
-                "401":
-                    $ref: "#/components/responses/Unauthorized"
-                "403":
-                    $ref: "#/components/responses/Forbidden"
-                "404":
-                    description: Game not found
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "409":
-                    description: Not the player's turn or game not in progress
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
+  /games/{id}/reject-end:
+    post:
+      operationId: rejectEndGame
+      summary: Reject the opponent's end-game proposal
+      description: |
+        The opponent rejects the end-game proposal. The game resumes with the
+        remaining turn time (minimum 10 seconds). Only the non-proposing player may call this.
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the game
+      responses:
+        "204":
+          description: Proposal rejected; game continues
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Game not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: No end proposal is pending or player is not the opponent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-    /player/state/{uid}:
-        get:
-            operationId: getPlayerStateUID
-            summary: Get user state
-            parameters:
-                - name: uid
-                  in: path
-                  description: Player ID
-                  required: true
-                  schema:
-                      type: string
-                      format: uuid
-                      description: The unique identifier of the player
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/PlayerState"
-                "400":
-                    description: Error when get player state
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
+  /games/{id}/skip:
+    post:
+      operationId: skipGame
+      summary: Skip turn
+      description: |
+        Ends the current turn without making a move. The turn passes to the opponent.
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the game
+      responses:
+        "204":
+          description: Turn skipped successfully
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Game not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Not the player's turn or game not in progress
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /player/state/{uid}:
+    get:
+      operationId: getPlayerStateUID
+      summary: Get user state
+      parameters:
+        - name: uid
+          in: path
+          description: Player ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+            description: The unique identifier of the player
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlayerState"
+        "400":
+          description: Error when get player state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
 components:
-    securitySchemes:
-        BearerAuth:
-            type: http
-            scheme: bearer
-            bearerFormat: JWT
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
 
-    responses:
-        Unauthorized:
-            description: Missing or invalid credentials.
-            content:
-                application/json:
-                    schema:
-                        $ref: "#/components/schemas/ErrorResponse"
-                    example:
-                        status: 401
-                        message: "Session required"
-                        type: "Unauthorized"
-        Forbidden:
-            description: Authenticated but not allowed to act on this resource.
-            content:
-                application/json:
-                    schema:
-                        $ref: "#/components/schemas/ErrorResponse"
-                    example:
-                        status: 403
-                        message: "not a participant of this game"
-                        type: "Forbidden"
-        InternalServerError:
-            description: Unexpected internal server error.
-            content:
-                application/json:
-                    schema:
-                        $ref: "#/components/schemas/ErrorResponse"
-                    example:
-                        status: 500
-                        message: "internal server error"
-                        type: "InternalServerError"
+  responses:
+    Unauthorized:
+      description: Missing or invalid credentials.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            status: 401
+            message: "Session required"
+            type: "Unauthorized"
+    Forbidden:
+      description: Authenticated but not allowed to act on this resource.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            status: 403
+            message: "not a participant of this game"
+            type: "Forbidden"
+    BadRequest:
+      description: Invalid request parameters.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            status: 400
+            message: "invalid period"
+            type: "BadRequest"
+    InternalServerError:
+      description: Unexpected internal server error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            status: 500
+            message: "internal server error"
+            type: "InternalServerError"
 
-    schemas:
-        Error:
-            type: object
-            properties:
-                code:
-                    description: Error code
-                    type: integer
-                message:
-                    description: Human-readable error message
-                    type: string
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          description: Error code
+          type: integer
+        message:
+          description: Human-readable error message
+          type: string
 
-        ErrorResponse:
-            type: object
-            properties:
-                status:
-                    description: the HTTP response code
-                    example: 401
-                    type: integer
-                message:
-                    description: a human-readable explanation of the error
-                    example: Bad Authentication data.
-                    type: string
-                type:
-                    description: Type of the error message
-                    example: OAuthException
-                    type: string
+    ErrorResponse:
+      type: object
+      properties:
+        status:
+          description: the HTTP response code
+          example: 401
+          type: integer
+        message:
+          description: a human-readable explanation of the error
+          example: Bad Authentication data.
+          type: string
+        type:
+          description: Type of the error message
+          example: OAuthException
+          type: string
 
-        SignupRequest:
-            type: object
-            required:
-                - firstname
-                - lastname
-                - email
-                - password
-            properties:
-                firstname:
-                    description: User's first name
-                    example: John
-                    type: string
-                lastname:
-                    description: User's last name
-                    example: Smith
-                    type: string
-                email:
-                    description: User's email
-                    example: js@example.org
-                    type: string
-                    format: email
-                password:
-                    description: User's password
-                    example: some_password
-                    type: string
+    SignupRequest:
+      type: object
+      required:
+        - firstname
+        - lastname
+        - email
+        - password
+      properties:
+        firstname:
+          description: User's first name
+          example: John
+          type: string
+        lastname:
+          description: User's last name
+          example: Smith
+          type: string
+        email:
+          description: User's email
+          example: js@example.org
+          type: string
+          format: email
+        password:
+          description: User's password
+          example: some_password
+          type: string
 
-        SignupResponse:
-            type: object
-            properties:
-                user:
-                    $ref: "#/components/schemas/Player"
-                access_token:
-                    description: Short-lived JWT access token (Authorization:&nbsp;Bearer)
-                    type: string
-                refresh_token:
-                    description: Opaque long-lived token used to obtain a new access token
-                    type: string
-                token_type:
-                    description: Always "Bearer"
-                    type: string
-                    example: Bearer
-                expires_in:
-                    description: Access token lifetime in seconds
-                    type: integer
-                    example: 3600
-                centrifugo_token:
-                    description: JWT for connecting to the Centrifugo WebSocket
-                    type: string
-                lobby_token:
-                    description: Centrifugo subscription JWT for the lobby channel
-                    type: string
+    SignupResponse:
+      type: object
+      properties:
+        user:
+          $ref: "#/components/schemas/Player"
+        access_token:
+          description: Short-lived JWT access token (Authorization:&nbsp;Bearer)
+          type: string
+        refresh_token:
+          description: Opaque long-lived token used to obtain a new access token
+          type: string
+        token_type:
+          description: Always "Bearer"
+          type: string
+          example: Bearer
+        expires_in:
+          description: Access token lifetime in seconds
+          type: integer
+          example: 3600
+        centrifugo_token:
+          description: JWT for connecting to the Centrifugo WebSocket
+          type: string
+        lobby_token:
+          description: Centrifugo subscription JWT for the lobby channel
+          type: string
 
-        Player:
-            type: object
-            properties:
-                uid:
-                    description: Player's ID in the system
-                    type: string
-                    format: uuid
-                firstname:
-                    description: Player's first name
-                    example: John
-                    type: string
-                lastname:
-                    description: Player's last name
-                    example: Smith
-                    type: string
-                exp:
-                    description: Player's total EXP
-                    type: integer
-                    format: int64
-                rating:
-                    description: Player's ELO rating
-                    type: integer
-                    format: int64
-                    example: 1000
+    Player:
+      type: object
+      properties:
+        uid:
+          description: Player's ID in the system
+          type: string
+          format: uuid
+        firstname:
+          description: Player's first name
+          example: John
+          type: string
+        lastname:
+          description: Player's last name
+          example: Smith
+          type: string
+        exp:
+          description: Player's total EXP
+          type: integer
+          format: int64
+        rating:
+          description: Player's ELO rating
+          type: integer
+          format: int64
+          example: 1000
 
-        AuthRequest:
-            type: object
-            required:
-                - email
-                - password
-            properties:
-                email:
-                    description: User's email
-                    example: js@example.org
-                    type: string
-                password:
-                    description: User's password
-                    example: some_password
-                    type: string
+    AuthRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          description: User's email
+          example: js@example.org
+          type: string
+        password:
+          description: User's password
+          example: some_password
+          type: string
 
-        AuthResponse:
-            type: object
-            properties:
-                player:
-                    $ref: "#/components/schemas/Player"
-                access_token:
-                    description: Short-lived JWT access token (Authorization:&nbsp;Bearer)
-                    type: string
-                refresh_token:
-                    description: Opaque long-lived token used to obtain a new access token
-                    type: string
-                token_type:
-                    description: Always "Bearer"
-                    type: string
-                    example: Bearer
-                expires_in:
-                    description: Access token lifetime in seconds
-                    type: integer
-                    example: 3600
-                centrifugo_token:
-                    description: JWT for connecting to the Centrifugo WebSocket
-                    type: string
-                lobby_token:
-                    description: Centrifugo subscription JWT for the lobby channel
-                    type: string
-                active_game:
-                    description: Present when the player is currently in an active game. Use this to reconnect after a disconnect.
-                    $ref: "#/components/schemas/ActiveGame"
+    AuthResponse:
+      type: object
+      properties:
+        player:
+          $ref: "#/components/schemas/Player"
+        access_token:
+          description: Short-lived JWT access token (Authorization:&nbsp;Bearer)
+          type: string
+        refresh_token:
+          description: Opaque long-lived token used to obtain a new access token
+          type: string
+        token_type:
+          description: Always "Bearer"
+          type: string
+          example: Bearer
+        expires_in:
+          description: Access token lifetime in seconds
+          type: integer
+          example: 3600
+        centrifugo_token:
+          description: JWT for connecting to the Centrifugo WebSocket
+          type: string
+        lobby_token:
+          description: Centrifugo subscription JWT for the lobby channel
+          type: string
+        active_game:
+          description: Present when the player is currently in an active game. Use this to reconnect after a disconnect.
+          $ref: "#/components/schemas/ActiveGame"
 
-        RefreshRequest:
-            type: object
-            required:
-                - refresh_token
-            properties:
-                refresh_token:
-                    description: The opaque refresh token previously issued
-                    type: string
+    RefreshRequest:
+      type: object
+      required:
+        - refresh_token
+      properties:
+        refresh_token:
+          description: The opaque refresh token previously issued
+          type: string
 
-        RefreshResponse:
-            type: object
-            properties:
-                access_token:
-                    description: New short-lived JWT access token
-                    type: string
-                refresh_token:
-                    description: New opaque refresh token (rotated; the old one is now invalid)
-                    type: string
-                token_type:
-                    description: Always "Bearer"
-                    type: string
-                    example: Bearer
-                expires_in:
-                    description: Access token lifetime in seconds
-                    type: integer
-                    example: 3600
+    RefreshResponse:
+      type: object
+      properties:
+        access_token:
+          description: New short-lived JWT access token
+          type: string
+        refresh_token:
+          description: New opaque refresh token (rotated; the old one is now invalid)
+          type: string
+        token_type:
+          description: Always "Bearer"
+          type: string
+          example: Bearer
+        expires_in:
+          description: Access token lifetime in seconds
+          type: integer
+          example: 3600
 
-        LogoutRequest:
-            type: object
-            properties:
-                refresh_token:
-                    description: Optional. The refresh token to revoke for this device.
-                    type: string
+    LogoutRequest:
+      type: object
+      properties:
+        refresh_token:
+          description: Optional. The refresh token to revoke for this device.
+          type: string
 
-        ActiveGame:
-            type: object
-            properties:
-                game_id:
-                    description: ID of the active game
-                    type: string
-                    format: uuid
-                game_token:
-                    description: Centrifugo subscription JWT for the game channel
-                    type: string
-                board:
-                    description: Current 5x5 board state
-                    type: array
-                    items:
-                        type: array
-                        items:
-                            type: string
-                current_turn_uid:
-                    description: ID of the player whose turn it is
-                    type: string
-                    format: uuid
-                move_number:
-                    type: integer
-                status:
-                    $ref: "#/components/schemas/GameStatus"
-                players:
-                    type: array
-                    items:
-                        $ref: "#/components/schemas/PlayerGameState"
+    ActiveGame:
+      type: object
+      properties:
+        game_id:
+          description: ID of the active game
+          type: string
+          format: uuid
+        game_token:
+          description: Centrifugo subscription JWT for the game channel
+          type: string
+        board:
+          description: Current 5x5 board state
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+        current_turn_uid:
+          description: ID of the player whose turn it is
+          type: string
+          format: uuid
+        move_number:
+          type: integer
+        status:
+          $ref: "#/components/schemas/GameStatus"
+        players:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlayerGameState"
 
-        GameStatus:
+    GameStatus:
+      type: string
+      enum:
+        - waiting
+        - in_progress
+        - finished
+      description: Current state of the game
+
+    LobbyPlayer:
+      type: object
+      properties:
+        uid:
+          description: Player's ID
+          type: string
+          format: uuid
+        exp:
+          description: Player's total EXP
+          type: integer
+          format: int64
+        rating:
+          description: Player's ELO rating
+          type: integer
+          format: int64
+          example: 1000
+
+    GameSummary:
+      type: object
+      properties:
+        id:
+          description: Game ID
+          type: string
+          format: uuid
+          example: "144e8a2b-3c1d-4e5f-a6b7-8c9d0e1f2a3b"
+        player_ids:
+          description: IDs of players participating in the game
+          type: array
+          items:
             type: string
-            enum:
-                - waiting
-                - in_progress
-                - finished
-            description: Current state of the game
+            format: uuid
+        players:
+          description: Players with EXP info
+          type: array
+          items:
+            $ref: "#/components/schemas/LobbyPlayer"
+        status:
+          $ref: "#/components/schemas/GameStatus"
+        started_at:
+          description: When the game was started (Unix timestamp in milliseconds)
+          type: integer
+          format: int64
+          example: 1712600000000
 
-        LobbyPlayer:
-            type: object
-            properties:
-                uid:
-                    description: Player's ID
-                    type: string
-                    format: uuid
-                exp:
-                    description: Player's total EXP
-                    type: integer
-                    format: int64
-                rating:
-                    description: Player's ELO rating
-                    type: integer
-                    format: int64
-                    example: 1000
+    CreateGameResponse:
+      type: object
+      properties:
+        game:
+          $ref: "#/components/schemas/GameSummary"
+        game_token:
+          description: Centrifugo subscription JWT for the game channel
+          type: string
 
-        GameSummary:
-            type: object
-            properties:
-                id:
-                    description: Game ID
-                    type: string
-                    format: uuid
-                    example: "144e8a2b-3c1d-4e5f-a6b7-8c9d0e1f2a3b"
-                player_ids:
-                    description: IDs of players participating in the game
-                    type: array
-                    items:
-                        type: string
-                        format: uuid
-                players:
-                    description: Players with EXP info
-                    type: array
-                    items:
-                        $ref: "#/components/schemas/LobbyPlayer"
-                status:
-                    $ref: "#/components/schemas/GameStatus"
-                started_at:
-                    description: When the game was started (Unix timestamp in milliseconds)
-                    type: integer
-                    format: int64
-                    example: 1712600000000
+    ListGamesResponse:
+      type: object
+      properties:
+        games:
+          type: array
+          items:
+            $ref: "#/components/schemas/GameSummary"
 
-        CreateGameResponse:
-            type: object
-            properties:
-                game:
-                    $ref: "#/components/schemas/GameSummary"
-                game_token:
-                    description: Centrifugo subscription JWT for the game channel
-                    type: string
+    JoinGameResponse:
+      type: object
+      properties:
+        game:
+          $ref: "#/components/schemas/GameSummary"
+        game_token:
+          description: Centrifugo subscription JWT for the game channel
+          type: string
+        board:
+          description: |
+            Initial 5x5 board state. Each row is an array of 5 single-character strings
+            (empty string means empty cell). Included so the joining player can render
+            the board immediately without waiting for the Centrifugo game_state event.
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+        current_turn_uid:
+          description: ID of the player whose turn it is first (the game creator)
+          type: string
 
-        ListGamesResponse:
-            type: object
-            properties:
-                games:
-                    type: array
-                    items:
-                        $ref: "#/components/schemas/GameSummary"
+    BoardCell:
+      description: >
+        A cell position on the 5×5 board, used in word_path.
+        The character at each cell is resolved server-side from the current board state;
+        clients do not need to send it. The new letter being placed is provided separately
+        in new_letter.char.
+      type: object
+      required:
+        - row
+        - col
+      properties:
+        row:
+          type: integer
+          minimum: 0
+          maximum: 4
+        col:
+          type: integer
+          minimum: 0
+          maximum: 4
 
-        JoinGameResponse:
-            type: object
-            properties:
-                game:
-                    $ref: "#/components/schemas/GameSummary"
-                game_token:
-                    description: Centrifugo subscription JWT for the game channel
-                    type: string
-                board:
-                    description: |
-                        Initial 5x5 board state. Each row is an array of 5 single-character strings
-                        (empty string means empty cell). Included so the joining player can render
-                        the board immediately without waiting for the Centrifugo game_state event.
-                    type: array
-                    items:
-                        type: array
-                        items:
-                            type: string
-                current_turn_uid:
-                    description: ID of the player whose turn it is first (the game creator)
-                    type: string
+    MoveRequest:
+      type: object
+      required:
+        - new_letter
+        - word_path
+      properties:
+        new_letter:
+          type: object
+          required:
+            - row
+            - col
+            - char
+          properties:
+            row:
+              type: integer
+              minimum: 0
+              maximum: 4
+            col:
+              type: integer
+              minimum: 0
+              maximum: 4
+            char:
+              type: string
+              maxLength: 1
+              description: Single Cyrillic letter to place
+        word_path:
+          type: array
+          minItems: 2
+          items:
+            $ref: "#/components/schemas/BoardCell"
 
-        BoardCell:
-            description: >
-                A cell position on the 5×5 board, used in word_path.
-                The character at each cell is resolved server-side from the current board state;
-                clients do not need to send it. The new letter being placed is provided separately
-                in new_letter.char.
-            type: object
-            required:
-                - row
-                - col
-            properties:
-                row:
-                    type: integer
-                    minimum: 0
-                    maximum: 4
-                col:
-                    type: integer
-                    minimum: 0
-                    maximum: 4
+    MoveResponse:
+      type: object
+      properties:
+        board:
+          description: Updated 5x5 board state
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+              maxLength: 1
+        current_turn_uid:
+          description: ID of the player whose turn it is now
+          type: string
+          format: uuid
+        players:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlayerGameState"
+        status:
+          $ref: "#/components/schemas/GameStatus"
+        move_number:
+          type: integer
 
-        MoveRequest:
-            type: object
-            required:
-                - new_letter
-                - word_path
-            properties:
-                new_letter:
-                    type: object
-                    required:
-                        - row
-                        - col
-                        - char
-                    properties:
-                        row:
-                            type: integer
-                            minimum: 0
-                            maximum: 4
-                        col:
-                            type: integer
-                            minimum: 0
-                            maximum: 4
-                        char:
-                            type: string
-                            maxLength: 1
-                            description: Single Cyrillic letter to place
-                word_path:
-                    type: array
-                    minItems: 2
-                    items:
-                        $ref: "#/components/schemas/BoardCell"
+    PlayerGameState:
+      type: object
+      properties:
+        uid:
+          description: Player's ID
+          type: string
+          format: uuid
+        exp:
+          description: Player's total EXP at the time of the event
+          type: integer
+          format: int64
+        rating:
+          description: Player's ELO rating at the time of the event
+          type: integer
+          format: int64
+          example: 1000
+        exp_gained:
+          description: EXP earned in this game (only present in game_over events)
+          type: integer
+        score:
+          description: Number of points scored in the current game
+          type: integer
+        words_count:
+          description: Number of words submitted by the player
+          type: integer
+        words:
+          description: List of words submitted by the player in this game
+          type: array
+          items:
+            type: string
 
-        MoveResponse:
-            type: object
-            properties:
-                board:
-                    description: Updated 5x5 board state
-                    type: array
-                    items:
-                        type: array
-                        items:
-                            type: string
-                            maxLength: 1
-                current_turn_uid:
-                    description: ID of the player whose turn it is now
-                    type: string
-                    format: uuid
-                players:
-                    type: array
-                    items:
-                        $ref: "#/components/schemas/PlayerGameState"
-                status:
-                    $ref: "#/components/schemas/GameStatus"
-                move_number:
-                    type: integer
+    EvGameCreated:
+      type: object
+      description: Published to the lobby channel when a new game is created
+      properties:
+        type:
+          type: string
+          enum: [game_created]
+        game:
+          $ref: "#/components/schemas/GameSummary"
 
-        PlayerGameState:
-            type: object
-            properties:
-                uid:
-                    description: Player's ID
-                    type: string
-                    format: uuid
-                exp:
-                    description: Player's total EXP at the time of the event
-                    type: integer
-                    format: int64
-                rating:
-                    description: Player's ELO rating at the time of the event
-                    type: integer
-                    format: int64
-                    example: 1000
-                exp_gained:
-                    description: EXP earned in this game (only present in game_over events)
-                    type: integer
-                score:
-                    description: Number of points scored in the current game
-                    type: integer
-                words_count:
-                    description: Number of words submitted by the player
-                    type: integer
-                words:
-                    description: List of words submitted by the player in this game
-                    type: array
-                    items:
-                        type: string
+    EvGameStarted:
+      type: object
+      description: Published to lobby and game:{id} channels when the second player joins
+      properties:
+        type:
+          type: string
+          enum: [game_started]
+        game:
+          $ref: "#/components/schemas/GameSummary"
 
-        EvGameCreated:
-            type: object
-            description: Published to the lobby channel when a new game is created
-            properties:
-                type:
-                    type: string
-                    enum: [game_created]
-                game:
-                    $ref: "#/components/schemas/GameSummary"
+    EvGameState:
+      type: object
+      description: |
+        Full game snapshot. Published to game:{id} at game start and after every move.
+        board is a 5x5 grid represented as an array of 5 rows, each row is an array of
+        5 single-character strings (empty string means the cell is empty).
+      properties:
+        type:
+          type: string
+          enum: [game_state]
+        game_id:
+          type: string
+          format: uuid
+        board:
+          type: array
+          minItems: 5
+          maxItems: 5
+          items:
+            type: array
+            minItems: 5
+            maxItems: 5
+            items:
+              type: string
+              maxLength: 1
+        current_turn_uid:
+          description: ID of the player whose turn it is
+          type: string
+          format: uuid
+        players:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlayerGameState"
+        status:
+          $ref: "#/components/schemas/GameStatus"
+        move_number:
+          description: Number of moves made so far (0 at game start)
+          type: integer
 
-        EvGameStarted:
-            type: object
-            description: Published to lobby and game:{id} channels when the second player joins
-            properties:
-                type:
-                    type: string
-                    enum: [game_started]
-                game:
-                    $ref: "#/components/schemas/GameSummary"
+    EvGameOver:
+      type: object
+      description: Published to game:{id} when the game ends
+      properties:
+        type:
+          type: string
+          enum: [game_over]
+        game_id:
+          type: string
+          format: uuid
+        winner_uid:
+          description: ID of the winner, absent if the game ended in a draw
+          type: string
+          format: uuid
+          nullable: true
+        players:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlayerGameState"
 
-        EvGameState:
-            type: object
-            description: |
-                Full game snapshot. Published to game:{id} at game start and after every move.
-                board is a 5x5 grid represented as an array of 5 rows, each row is an array of
-                5 single-character strings (empty string means the cell is empty).
-            properties:
-                type:
-                    type: string
-                    enum: [game_state]
-                game_id:
-                    type: string
-                    format: uuid
-                board:
-                    type: array
-                    minItems: 5
-                    maxItems: 5
-                    items:
-                        type: array
-                        minItems: 5
-                        maxItems: 5
-                        items:
-                            type: string
-                            maxLength: 1
-                current_turn_uid:
-                    description: ID of the player whose turn it is
-                    type: string
-                    format: uuid
-                players:
-                    type: array
-                    items:
-                        $ref: "#/components/schemas/PlayerGameState"
-                status:
-                    $ref: "#/components/schemas/GameStatus"
-                move_number:
-                    description: Number of moves made so far (0 at game start)
-                    type: integer
+    EvEndProposal:
+      type: object
+      description: Published to game:{id} when the current player proposes to end the game
+      properties:
+        type:
+          type: string
+          enum: [end_proposal]
+        game_id:
+          type: string
+          format: uuid
+        proposer_uid:
+          description: ID of the player who proposed to end
+          type: string
+          format: uuid
 
-        EvGameOver:
-            type: object
-            description: Published to game:{id} when the game ends
-            properties:
-                type:
-                    type: string
-                    enum: [game_over]
-                game_id:
-                    type: string
-                    format: uuid
-                winner_uid:
-                    description: ID of the winner, absent if the game ended in a draw
-                    type: string
-                    format: uuid
-                    nullable: true
-                players:
-                    type: array
-                    items:
-                        $ref: "#/components/schemas/PlayerGameState"
+    EvEndProposalResult:
+      type: object
+      description: Published to game:{id} when the opponent responds to the end proposal
+      properties:
+        type:
+          type: string
+          enum: [end_proposal_result]
+        game_id:
+          type: string
+          format: uuid
+        accepted:
+          type: boolean
+        remaining_ms:
+          description: Remaining turn time in milliseconds (only present when accepted=false)
+          type: integer
+          format: int64
 
-        EvEndProposal:
-            type: object
-            description: Published to game:{id} when the current player proposes to end the game
-            properties:
-                type:
-                    type: string
-                    enum: [end_proposal]
-                game_id:
-                    type: string
-                    format: uuid
-                proposer_uid:
-                    description: ID of the player who proposed to end
-                    type: string
-                    format: uuid
+    PlayerState:
+      type: object
+      properties:
+        uid:
+          description: Player's ID in the system
+          type: string
+          format: uuid
+        nickname:
+          description: Generated nickname in the system
+          example: JohnSmith
+          type: string
+        exp:
+          description: Player's exp points in the system
+          example: 100
+          type: integer
+          format: int64
+        rating:
+          description: Player's ELO rating in the system
+          example: 1000
+          type: integer
+          format: int64
+        lives:
+          description: Player's lives count in the system
+          example: 3
+          type: integer
+          format: int64
+        flags:
+          description: Some Player's flags.
+          example: 10
+          type: integer
+          format: int64
+        game_id:
+          description: Game's ID (if game_id empty or absent then player in the lobby)
+          example: 144
+          type: string
+          format: uuid
 
-        EvEndProposalResult:
-            type: object
-            description: Published to game:{id} when the opponent responds to the end proposal
-            properties:
-                type:
-                    type: string
-                    enum: [end_proposal_result]
-                game_id:
-                    type: string
-                    format: uuid
-                accepted:
-                    type: boolean
-                remaining_ms:
-                    description: Remaining turn time in milliseconds (only present when accepted=false)
-                    type: integer
-                    format: int64
+    LeaderboardResponse:
+      type: object
+      properties:
+        period:
+          description: Leaderboard period
+          type: string
+          enum: [week, month]
+        sort:
+          description: Sort field
+          type: string
+          enum: [rating, exp]
+        generated_at:
+          description: Unix timestamp in milliseconds when the leaderboard was generated
+          type: integer
+          format: int64
+        players:
+          description: Leaderboard entries ordered by rank
+          type: array
+          items:
+            $ref: "#/components/schemas/LeaderboardEntry"
 
-        PlayerState:
-            type: object
-            properties:
-                uid:
-                    description: Player's ID in the system
-                    type: string
-                    format: uuid
-                nickname:
-                    description: Generated nickname in the system
-                    example: JohnSmith
-                    type: string
-                exp:
-                    description: Player's exp points in the system
-                    example: 100
-                    type: integer
-                    format: int64
-                rating:
-                    description: Player's ELO rating in the system
-                    example: 1000
-                    type: integer
-                    format: int64
-                lives:
-                    description: Player's lives count in the system
-                    example: 3
-                    type: integer
-                    format: int64
-                flags:
-                    description: Some Player's flags.
-                    example: 10
-                    type: integer
-                    format: int64
-                game_id:
-                    description: Game's ID (if game_id empty or absent then player in the lobby)
-                    example: 144
-                    type: string
-                    format: uuid
+    LeaderboardEntry:
+      type: object
+      properties:
+        rank:
+          description: Position in the leaderboard (1-based)
+          type: integer
+          example: 1
+        uid:
+          description: Player's ID
+          type: string
+          format: uuid
+        nickname:
+          description: Player's generated nickname
+          type: string
+          example: JohnSmith
+        rating:
+          description: Player's ELO rating
+          type: integer
+          format: int64
+          example: 1200
+        exp:
+          description: Player's total EXP
+          type: integer
+          format: int64
+          example: 1500
 
-    headers:
-        X-Request-ID:
-            description: Monotonically increasing client sequence number.
-            schema:
-                type: integer
-                minimum: 1
-                format: int64
-        X-Server-Time:
-            description: Server Unix timestamp in milliseconds.
-            schema:
-                type: integer
-                format: int64
-        Retry-After:
-            description: Seconds until the rate-limited or cooled-down action may be retried.
-            schema:
-                type: integer
-        ETag:
-            description: Entity tag for conditional GET caching.
-            schema:
-                type: string
-        Cache-Control:
-            description: Cache directive.
-            schema:
-                type: string
-        X-RateLimit-Limit:
-            description: Maximum requests allowed in the current window.
-            schema:
-                type: integer
-        X-RateLimit-Remaining:
-            description: Requests remaining in the current window.
-            schema:
-                type: integer
-        X-RateLimit-Reset:
-            description: When the current rate-limit window resets (ISO 8601).
-            schema:
-                type: string
-                format: date-time
+  headers:
+    X-Request-ID:
+      description: Monotonically increasing client sequence number.
+      schema:
+        type: integer
+        minimum: 1
+        format: int64
+    X-Server-Time:
+      description: Server Unix timestamp in milliseconds.
+      schema:
+        type: integer
+        format: int64
+    Retry-After:
+      description: Seconds until the rate-limited or cooled-down action may be retried.
+      schema:
+        type: integer
+    ETag:
+      description: Entity tag for conditional GET caching.
+      schema:
+        type: string
+    Cache-Control:
+      description: Cache directive.
+      schema:
+        type: string
+    X-RateLimit-Limit:
+      description: Maximum requests allowed in the current window.
+      schema:
+        type: integer
+    X-RateLimit-Remaining:
+      description: Requests remaining in the current window.
+      schema:
+        type: integer
+    X-RateLimit-Reset:
+      description: When the current rate-limit window resets (ISO 8601).
+      schema:
+        type: string
+        format: date-time
 
-    parameters:
-        RequestIdHeader:
-            in: header
-            name: X-Request-ID
-            required: true
-            schema:
-                type: integer
-                format: int64
-                minimum: 1
+  parameters:
+    RequestIdHeader:
+      in: header
+      name: X-Request-ID
+      required: true
+      schema:
+        type: integer
+        format: int64
+        minimum: 1

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rustwizard/balda/internal/game"
 	"github.com/rustwizard/balda/internal/game/bot"
 	"github.com/rustwizard/balda/internal/gamecoord"
+	"github.com/rustwizard/balda/internal/leaderboard"
 	"github.com/rustwizard/balda/internal/lobby"
 	"github.com/rustwizard/balda/internal/matchmaking"
 	"github.com/rustwizard/balda/internal/presence"
@@ -169,7 +170,9 @@ var serverCmd = &cobra.Command{
 			return err
 		})
 
-		svc := service.New(lby, mm, s)
+		lb := leaderboard.NewService(s, rdb, 5*time.Minute)
+
+		svc := service.New(lby, mm, s, lb)
 
 		h := handlers.New(svc, pres, cfg.Auth.JWTSecret, cf, cfg.Centrifugo.TokenHMACSecret)
 

--- a/internal/leaderboard/service.go
+++ b/internal/leaderboard/service.go
@@ -1,0 +1,98 @@
+package leaderboard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rustwizard/balda/internal/storage"
+)
+
+const defaultLimit = 100
+
+// Service builds leaderboards with Redis caching.
+type Service struct {
+	st  *storage.Balda
+	rdb *redis.Client
+	ttl time.Duration
+}
+
+// NewService creates a leaderboard service. rdb may be nil to disable caching.
+func NewService(st *storage.Balda, rdb *redis.Client, ttl time.Duration) *Service {
+	return &Service{st: st, rdb: rdb, ttl: ttl}
+}
+
+// Entry aliases storage.LeaderboardEntry to avoid leaking the storage type upward.
+type Entry = storage.LeaderboardEntry
+
+// Request holds validated leaderboard parameters.
+type Request struct {
+	Period string // week | month
+	Sort   string // rating | exp
+	Limit  int
+}
+
+// GetLeaderboard returns the top players for the requested period and sort order.
+// It caches the result in Redis for the configured TTL.
+func (s *Service) GetLeaderboard(ctx context.Context, req Request) ([]Entry, time.Time, error) {
+	if req.Period != "week" && req.Period != "month" {
+		return nil, time.Time{}, fmt.Errorf("invalid period %q", req.Period)
+	}
+	if req.Sort != "rating" && req.Sort != "exp" {
+		req.Sort = "rating"
+	}
+	if req.Limit <= 0 || req.Limit > 100 {
+		req.Limit = defaultLimit
+	}
+
+	now := time.Now().UTC()
+	var periodStart time.Time
+	switch req.Period {
+	case "week":
+		periodStart = now.AddDate(0, 0, -7)
+	case "month":
+		periodStart = now.AddDate(0, 0, -30)
+	}
+
+	key := cacheKey(req.Period, req.Sort, req.Limit)
+
+	// Try cache first.
+	if s.rdb != nil {
+		cached, err := s.rdb.Get(ctx, key).Result()
+		if err == nil {
+			var entries []Entry
+			if err := json.Unmarshal([]byte(cached), &entries); err == nil {
+				return entries, now, nil
+			}
+			slog.Warn("leaderboard cache unmarshal failed", slog.Any("error", err))
+		} else if !errors.Is(err, redis.Nil) {
+			slog.Error("leaderboard cache read failed", slog.Any("error", err))
+		}
+	}
+
+	// Cache miss or Redis unavailable — query the database.
+	entries, err := s.st.GetLeaderboard(ctx, periodStart, req.Sort, req.Limit)
+	if err != nil {
+		return nil, now, err
+	}
+
+	// Best-effort cache write.
+	if s.rdb != nil {
+		data, err := json.Marshal(entries)
+		if err == nil {
+			if err := s.rdb.Set(ctx, key, data, s.ttl).Err(); err != nil {
+				slog.Error("leaderboard cache write failed", slog.Any("error", err))
+			}
+		}
+	}
+
+	return entries, now, nil
+}
+
+func cacheKey(period, sort string, limit int) string {
+	return fmt.Sprintf("leaderboard:%s:%s:%d", period, sort, limit)
+}

--- a/internal/server/ogen/oas_client_gen.go
+++ b/internal/server/ogen/oas_client_gen.go
@@ -55,6 +55,13 @@ type Invoker interface {
 	//
 	// POST /games/with-bot
 	CreateGameWithBot(ctx context.Context) (CreateGameWithBotRes, error)
+	// GetLeaderboard invokes getLeaderboard operation.
+	//
+	// Returns the top players by current rating or total EXP who were active during the requested period.
+	// Results are cached for 5 minutes.
+	//
+	// GET /leaderboard
+	GetLeaderboard(ctx context.Context, params GetLeaderboardParams) (GetLeaderboardRes, error)
 	// GetPlayerStateUID invokes getPlayerStateUID operation.
 	//
 	// Get user state.
@@ -606,6 +613,139 @@ func (c *Client) sendCreateGameWithBot(ctx context.Context) (res CreateGameWithB
 
 	stage = "DecodeResponse"
 	result, err := decodeCreateGameWithBotResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// GetLeaderboard invokes getLeaderboard operation.
+//
+// Returns the top players by current rating or total EXP who were active during the requested period.
+// Results are cached for 5 minutes.
+//
+// GET /leaderboard
+func (c *Client) GetLeaderboard(ctx context.Context, params GetLeaderboardParams) (GetLeaderboardRes, error) {
+	res, err := c.sendGetLeaderboard(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendGetLeaderboard(ctx context.Context, params GetLeaderboardParams) (res GetLeaderboardRes, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getLeaderboard"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.URLTemplateKey.String("/leaderboard"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, GetLeaderboardOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/leaderboard"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeQueryParams"
+	q := uri.NewQueryEncoder()
+	{
+		// Encode "period" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "period",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			return e.EncodeValue(conv.StringToString(string(params.Period)))
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "sort" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "sort",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Sort.Get(); ok {
+				return e.EncodeValue(conv.StringToString(string(val)))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "limit" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "limit",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Limit.Get(); ok {
+				return e.EncodeValue(conv.IntToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	u.RawQuery = q.Values().Encode()
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer func() {
+		// Drain the body to EOF before closing, so the underlying
+		// connection can be reused by the Transport regardless of the
+		// response status code. See https://github.com/ogen-go/ogen/issues/1670.
+		_, _ = io.Copy(io.Discard, body)
+		_ = body.Close()
+	}()
+
+	stage = "DecodeResponse"
+	result, err := decodeGetLeaderboardResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/internal/server/ogen/oas_handlers_gen.go
+++ b/internal/server/ogen/oas_handlers_gen.go
@@ -709,6 +709,158 @@ func (s *Server) handleCreateGameWithBotRequest(args [0]string, argsEscaped bool
 	}
 }
 
+// handleGetLeaderboardRequest handles getLeaderboard operation.
+//
+// Returns the top players by current rating or total EXP who were active during the requested period.
+// Results are cached for 5 minutes.
+//
+// GET /leaderboard
+func (s *Server) handleGetLeaderboardRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getLeaderboard"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/leaderboard"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), GetLeaderboardOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(attrs...)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: GetLeaderboardOperation,
+			ID:   "getLeaderboard",
+		}
+	)
+	params, err := decodeGetLeaderboardParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var rawBody []byte
+
+	var response GetLeaderboardRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    GetLeaderboardOperation,
+			OperationSummary: "Get weekly or monthly leaderboard",
+			OperationID:      "getLeaderboard",
+			Body:             nil,
+			RawBody:          rawBody,
+			Params: middleware.Parameters{
+				{
+					Name: "period",
+					In:   "query",
+				}: params.Period,
+				{
+					Name: "sort",
+					In:   "query",
+				}: params.Sort,
+				{
+					Name: "limit",
+					In:   "query",
+				}: params.Limit,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = GetLeaderboardParams
+			Response = GetLeaderboardRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackGetLeaderboardParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.GetLeaderboard(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.GetLeaderboard(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeGetLeaderboardResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleGetPlayerStateUIDRequest handles getPlayerStateUID operation.
 //
 // Get user state.

--- a/internal/server/ogen/oas_interfaces_gen.go
+++ b/internal/server/ogen/oas_interfaces_gen.go
@@ -17,6 +17,10 @@ type CreateGameWithBotRes interface {
 	createGameWithBotRes()
 }
 
+type GetLeaderboardRes interface {
+	getLeaderboardRes()
+}
+
 type GetPlayerStateUIDRes interface {
 	getPlayerStateUIDRes()
 }

--- a/internal/server/ogen/oas_json_gen.go
+++ b/internal/server/ogen/oas_json_gen.go
@@ -1262,6 +1262,82 @@ func (s *GameSummary) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes GetLeaderboardBadRequest as json.
+func (s *GetLeaderboardBadRequest) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes GetLeaderboardBadRequest from json.
+func (s *GetLeaderboardBadRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode GetLeaderboardBadRequest to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = GetLeaderboardBadRequest(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *GetLeaderboardBadRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *GetLeaderboardBadRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes GetLeaderboardInternalServerError as json.
+func (s *GetLeaderboardInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes GetLeaderboardInternalServerError from json.
+func (s *GetLeaderboardInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode GetLeaderboardInternalServerError to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = GetLeaderboardInternalServerError(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *GetLeaderboardInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *GetLeaderboardInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes JoinGameConflict as json.
 func (s *JoinGameConflict) Encode(e *jx.Encoder) {
 	unwrapped := (*ErrorResponse)(s)
@@ -1549,6 +1625,342 @@ func (s *JoinGameUnauthorized) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *JoinGameUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *LeaderboardEntry) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *LeaderboardEntry) encodeFields(e *jx.Encoder) {
+	{
+		if s.Rank.Set {
+			e.FieldStart("rank")
+			s.Rank.Encode(e)
+		}
+	}
+	{
+		if s.UID.Set {
+			e.FieldStart("uid")
+			s.UID.Encode(e)
+		}
+	}
+	{
+		if s.Nickname.Set {
+			e.FieldStart("nickname")
+			s.Nickname.Encode(e)
+		}
+	}
+	{
+		if s.Rating.Set {
+			e.FieldStart("rating")
+			s.Rating.Encode(e)
+		}
+	}
+	{
+		if s.Exp.Set {
+			e.FieldStart("exp")
+			s.Exp.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfLeaderboardEntry = [5]string{
+	0: "rank",
+	1: "uid",
+	2: "nickname",
+	3: "rating",
+	4: "exp",
+}
+
+// Decode decodes LeaderboardEntry from json.
+func (s *LeaderboardEntry) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode LeaderboardEntry to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "rank":
+			if err := func() error {
+				s.Rank.Reset()
+				if err := s.Rank.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rank\"")
+			}
+		case "uid":
+			if err := func() error {
+				s.UID.Reset()
+				if err := s.UID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"uid\"")
+			}
+		case "nickname":
+			if err := func() error {
+				s.Nickname.Reset()
+				if err := s.Nickname.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nickname\"")
+			}
+		case "rating":
+			if err := func() error {
+				s.Rating.Reset()
+				if err := s.Rating.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rating\"")
+			}
+		case "exp":
+			if err := func() error {
+				s.Exp.Reset()
+				if err := s.Exp.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"exp\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode LeaderboardEntry")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *LeaderboardEntry) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *LeaderboardEntry) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *LeaderboardResponse) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *LeaderboardResponse) encodeFields(e *jx.Encoder) {
+	{
+		if s.Period.Set {
+			e.FieldStart("period")
+			s.Period.Encode(e)
+		}
+	}
+	{
+		if s.Sort.Set {
+			e.FieldStart("sort")
+			s.Sort.Encode(e)
+		}
+	}
+	{
+		if s.GeneratedAt.Set {
+			e.FieldStart("generated_at")
+			s.GeneratedAt.Encode(e)
+		}
+	}
+	{
+		if s.Players != nil {
+			e.FieldStart("players")
+			e.ArrStart()
+			for _, elem := range s.Players {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+}
+
+var jsonFieldsNameOfLeaderboardResponse = [4]string{
+	0: "period",
+	1: "sort",
+	2: "generated_at",
+	3: "players",
+}
+
+// Decode decodes LeaderboardResponse from json.
+func (s *LeaderboardResponse) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode LeaderboardResponse to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "period":
+			if err := func() error {
+				s.Period.Reset()
+				if err := s.Period.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"period\"")
+			}
+		case "sort":
+			if err := func() error {
+				s.Sort.Reset()
+				if err := s.Sort.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"sort\"")
+			}
+		case "generated_at":
+			if err := func() error {
+				s.GeneratedAt.Reset()
+				if err := s.GeneratedAt.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"generated_at\"")
+			}
+		case "players":
+			if err := func() error {
+				s.Players = make([]LeaderboardEntry, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem LeaderboardEntry
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.Players = append(s.Players, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"players\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode LeaderboardResponse")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *LeaderboardResponse) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *LeaderboardResponse) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes LeaderboardResponsePeriod as json.
+func (s LeaderboardResponsePeriod) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes LeaderboardResponsePeriod from json.
+func (s *LeaderboardResponsePeriod) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode LeaderboardResponsePeriod to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch LeaderboardResponsePeriod(v) {
+	case LeaderboardResponsePeriodWeek:
+		*s = LeaderboardResponsePeriodWeek
+	case LeaderboardResponsePeriodMonth:
+		*s = LeaderboardResponsePeriodMonth
+	default:
+		*s = LeaderboardResponsePeriod(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s LeaderboardResponsePeriod) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *LeaderboardResponsePeriod) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes LeaderboardResponseSort as json.
+func (s LeaderboardResponseSort) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes LeaderboardResponseSort from json.
+func (s *LeaderboardResponseSort) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode LeaderboardResponseSort to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch LeaderboardResponseSort(v) {
+	case LeaderboardResponseSortRating:
+		*s = LeaderboardResponseSortRating
+	case LeaderboardResponseSortExp:
+		*s = LeaderboardResponseSortExp
+	default:
+		*s = LeaderboardResponseSort(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s LeaderboardResponseSort) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *LeaderboardResponseSort) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -2598,6 +3010,72 @@ func (s OptInt64) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptInt64) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes LeaderboardResponsePeriod as json.
+func (o OptLeaderboardResponsePeriod) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes LeaderboardResponsePeriod from json.
+func (o *OptLeaderboardResponsePeriod) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptLeaderboardResponsePeriod to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptLeaderboardResponsePeriod) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptLeaderboardResponsePeriod) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes LeaderboardResponseSort as json.
+func (o OptLeaderboardResponseSort) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes LeaderboardResponseSort from json.
+func (o *OptLeaderboardResponseSort) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptLeaderboardResponseSort to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptLeaderboardResponseSort) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptLeaderboardResponseSort) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/server/ogen/oas_operations_gen.go
+++ b/internal/server/ogen/oas_operations_gen.go
@@ -10,6 +10,7 @@ const (
 	AuthOperation              OperationName = "Auth"
 	CreateGameOperation        OperationName = "CreateGame"
 	CreateGameWithBotOperation OperationName = "CreateGameWithBot"
+	GetLeaderboardOperation    OperationName = "GetLeaderboard"
 	GetPlayerStateUIDOperation OperationName = "GetPlayerStateUID"
 	JoinGameOperation          OperationName = "JoinGame"
 	ListGamesOperation         OperationName = "ListGames"

--- a/internal/server/ogen/oas_parameters_gen.go
+++ b/internal/server/ogen/oas_parameters_gen.go
@@ -81,6 +81,226 @@ func decodeAcceptEndGameParams(args [1]string, argsEscaped bool, r *http.Request
 	return params, nil
 }
 
+// GetLeaderboardParams is parameters of getLeaderboard operation.
+type GetLeaderboardParams struct {
+	// Leaderboard period.
+	Period GetLeaderboardPeriod
+	// Sort field.
+	Sort OptGetLeaderboardSort `json:",omitempty,omitzero"`
+	// Maximum number of entries to return.
+	Limit OptInt `json:",omitempty,omitzero"`
+}
+
+func unpackGetLeaderboardParams(packed middleware.Parameters) (params GetLeaderboardParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "period",
+			In:   "query",
+		}
+		params.Period = packed[key].(GetLeaderboardPeriod)
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "sort",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Sort = v.(OptGetLeaderboardSort)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "limit",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Limit = v.(OptInt)
+		}
+	}
+	return params
+}
+
+func decodeGetLeaderboardParams(args [0]string, argsEscaped bool, r *http.Request) (params GetLeaderboardParams, _ error) {
+	q := uri.NewQueryDecoder(r.URL.Query())
+	// Decode query: period.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "period",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.Period = GetLeaderboardPeriod(c)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if err := params.Period.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "period",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Set default value for query: sort.
+	{
+		val := GetLeaderboardSort("rating")
+		params.Sort.SetTo(val)
+	}
+	// Decode query: sort.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "sort",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotSortVal GetLeaderboardSort
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotSortVal = GetLeaderboardSort(c)
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Sort.SetTo(paramsDotSortVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if value, ok := params.Sort.Get(); ok {
+					if err := func() error {
+						if err := value.Validate(); err != nil {
+							return err
+						}
+						return nil
+					}(); err != nil {
+						return err
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "sort",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Set default value for query: limit.
+	{
+		val := int(100)
+		params.Limit.SetTo(val)
+	}
+	// Decode query: limit.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "limit",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotLimitVal int
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToInt(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotLimitVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Limit.SetTo(paramsDotLimitVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+			if err := func() error {
+				if value, ok := params.Limit.Get(); ok {
+					if err := func() error {
+						if err := (validate.Int{
+							MinSet:        true,
+							Min:           1,
+							MaxSet:        true,
+							Max:           100,
+							MinExclusive:  false,
+							MaxExclusive:  false,
+							MultipleOfSet: false,
+							MultipleOf:    0,
+							Pattern:       nil,
+						}).Validate(int64(value)); err != nil {
+							return errors.Wrap(err, "int")
+						}
+						return nil
+					}(); err != nil {
+						return err
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "limit",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
 // GetPlayerStateUIDParams is parameters of getPlayerStateUID operation.
 type GetPlayerStateUIDParams struct {
 	// Player ID.

--- a/internal/server/ogen/oas_response_decoders_gen.go
+++ b/internal/server/ogen/oas_response_decoders_gen.go
@@ -489,6 +489,126 @@ func decodeCreateGameWithBotResponse(resp *http.Response) (res CreateGameWithBot
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
+func decodeGetLeaderboardResponse(resp *http.Response) (res GetLeaderboardRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response LeaderboardResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 400:
+		// Code 400.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response GetLeaderboardBadRequest
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response GetLeaderboardInternalServerError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
 func decodeGetPlayerStateUIDResponse(resp *http.Response) (res GetPlayerStateUIDRes, _ error) {
 	switch resp.StatusCode {
 	case 200:

--- a/internal/server/ogen/oas_response_encoders_gen.go
+++ b/internal/server/ogen/oas_response_encoders_gen.go
@@ -191,6 +191,50 @@ func encodeCreateGameWithBotResponse(response CreateGameWithBotRes, w http.Respo
 	}
 }
 
+func encodeGetLeaderboardResponse(response GetLeaderboardRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *LeaderboardResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *GetLeaderboardBadRequest:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(400)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *GetLeaderboardInternalServerError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodeGetPlayerStateUIDResponse(response GetPlayerStateUIDRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *PlayerState:

--- a/internal/server/ogen/oas_router_gen.go
+++ b/internal/server/ogen/oas_router_gen.go
@@ -14,10 +14,10 @@ var (
 	rn5AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
-	rn12AllowedHeaders = map[string]string{
+	rn13AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type",
 	}
-	rn17AllowedHeaders = map[string]string{
+	rn18AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
 	rn6AllowedHeaders = map[string]string{
@@ -30,25 +30,25 @@ var (
 	rn3AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn11AllowedHeaders = map[string]string{
-		"POST": "Authorization",
-	}
-	rn13AllowedHeaders = map[string]string{
-		"POST": "Authorization,Content-Type",
-	}
-	rn15AllowedHeaders = map[string]string{
-		"POST": "Authorization",
-	}
-	rn18AllowedHeaders = map[string]string{
-		"POST": "Authorization",
-	}
-	rn21AllowedHeaders = map[string]string{
+	rn12AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
 	rn14AllowedHeaders = map[string]string{
+		"POST": "Authorization,Content-Type",
+	}
+	rn16AllowedHeaders = map[string]string{
+		"POST": "Authorization",
+	}
+	rn19AllowedHeaders = map[string]string{
+		"POST": "Authorization",
+	}
+	rn22AllowedHeaders = map[string]string{
+		"POST": "Authorization",
+	}
+	rn15AllowedHeaders = map[string]string{
 		"POST": "Authorization,X-Request-Id",
 	}
-	rn20AllowedHeaders = map[string]string{
+	rn21AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
 )
@@ -156,7 +156,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn12AllowedHeaders,
+									allowedHeaders: rn13AllowedHeaders,
 									acceptPost:     "application/json",
 									acceptPatch:    "",
 								})
@@ -181,7 +181,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn17AllowedHeaders,
+									allowedHeaders: rn18AllowedHeaders,
 									acceptPost:     "application/json",
 									acceptPatch:    "",
 								})
@@ -329,7 +329,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn11AllowedHeaders,
+										allowedHeaders: rn12AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -356,7 +356,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn13AllowedHeaders,
+										allowedHeaders: rn14AllowedHeaders,
 										acceptPost:     "application/json",
 										acceptPatch:    "",
 									})
@@ -383,7 +383,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn15AllowedHeaders,
+										allowedHeaders: rn16AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -410,7 +410,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn18AllowedHeaders,
+										allowedHeaders: rn19AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -437,7 +437,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn21AllowedHeaders,
+										allowedHeaders: rn22AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -450,6 +450,31 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 					}
 
+				}
+
+			case 'l': // Prefix: "leaderboard"
+
+				if l := len("leaderboard"); len(elem) >= l && elem[0:l] == "leaderboard" {
+					elem = elem[l:]
+				} else {
+					break
+				}
+
+				if len(elem) == 0 {
+					// Leaf node.
+					switch r.Method {
+					case "GET":
+						s.handleGetLeaderboardRequest([0]string{}, elemIsEscaped, w, r)
+					default:
+						s.notAllowed(w, r, notAllowedParams{
+							allowedMethods: "GET",
+							allowedHeaders: nil,
+							acceptPost:     "",
+							acceptPatch:    "",
+						})
+					}
+
+					return
 				}
 
 			case 'p': // Prefix: "player/state/"
@@ -516,7 +541,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn14AllowedHeaders,
+								allowedHeaders: rn15AllowedHeaders,
 								acceptPost:     "",
 								acceptPatch:    "",
 							})
@@ -541,7 +566,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn20AllowedHeaders,
+								allowedHeaders: rn21AllowedHeaders,
 								acceptPost:     "application/json",
 								acceptPatch:    "",
 							})
@@ -993,6 +1018,31 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 
 					}
 
+				}
+
+			case 'l': // Prefix: "leaderboard"
+
+				if l := len("leaderboard"); len(elem) >= l && elem[0:l] == "leaderboard" {
+					elem = elem[l:]
+				} else {
+					break
+				}
+
+				if len(elem) == 0 {
+					// Leaf node.
+					switch method {
+					case "GET":
+						r.name = GetLeaderboardOperation
+						r.summary = "Get weekly or monthly leaderboard"
+						r.operationID = "getLeaderboard"
+						r.operationGroup = ""
+						r.pathPattern = "/leaderboard"
+						r.args = args
+						r.count = 0
+						return r, true
+					default:
+						return
+					}
 				}
 
 			case 'p': // Prefix: "player/state/"

--- a/internal/server/ogen/oas_schemas_gen.go
+++ b/internal/server/ogen/oas_schemas_gen.go
@@ -499,6 +499,96 @@ func (s *GameSummary) SetStartedAt(val OptInt64) {
 	s.StartedAt = val
 }
 
+type GetLeaderboardBadRequest ErrorResponse
+
+func (*GetLeaderboardBadRequest) getLeaderboardRes() {}
+
+type GetLeaderboardInternalServerError ErrorResponse
+
+func (*GetLeaderboardInternalServerError) getLeaderboardRes() {}
+
+type GetLeaderboardPeriod string
+
+const (
+	GetLeaderboardPeriodWeek  GetLeaderboardPeriod = "week"
+	GetLeaderboardPeriodMonth GetLeaderboardPeriod = "month"
+)
+
+// AllValues returns all GetLeaderboardPeriod values.
+func (GetLeaderboardPeriod) AllValues() []GetLeaderboardPeriod {
+	return []GetLeaderboardPeriod{
+		GetLeaderboardPeriodWeek,
+		GetLeaderboardPeriodMonth,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s GetLeaderboardPeriod) MarshalText() ([]byte, error) {
+	switch s {
+	case GetLeaderboardPeriodWeek:
+		return []byte(s), nil
+	case GetLeaderboardPeriodMonth:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *GetLeaderboardPeriod) UnmarshalText(data []byte) error {
+	switch GetLeaderboardPeriod(data) {
+	case GetLeaderboardPeriodWeek:
+		*s = GetLeaderboardPeriodWeek
+		return nil
+	case GetLeaderboardPeriodMonth:
+		*s = GetLeaderboardPeriodMonth
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+type GetLeaderboardSort string
+
+const (
+	GetLeaderboardSortRating GetLeaderboardSort = "rating"
+	GetLeaderboardSortExp    GetLeaderboardSort = "exp"
+)
+
+// AllValues returns all GetLeaderboardSort values.
+func (GetLeaderboardSort) AllValues() []GetLeaderboardSort {
+	return []GetLeaderboardSort{
+		GetLeaderboardSortRating,
+		GetLeaderboardSortExp,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s GetLeaderboardSort) MarshalText() ([]byte, error) {
+	switch s {
+	case GetLeaderboardSortRating:
+		return []byte(s), nil
+	case GetLeaderboardSortExp:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *GetLeaderboardSort) UnmarshalText(data []byte) error {
+	switch GetLeaderboardSort(data) {
+	case GetLeaderboardSortRating:
+		*s = GetLeaderboardSortRating
+		return nil
+	case GetLeaderboardSortExp:
+		*s = GetLeaderboardSortExp
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
 type JoinGameConflict ErrorResponse
 
 func (*JoinGameConflict) joinGameRes() {}
@@ -570,6 +660,208 @@ func (*JoinGameResponse) joinGameRes()          {}
 type JoinGameUnauthorized ErrorResponse
 
 func (*JoinGameUnauthorized) joinGameRes() {}
+
+// Ref: #/components/schemas/LeaderboardEntry
+type LeaderboardEntry struct {
+	// Position in the leaderboard (1-based).
+	Rank OptInt `json:"rank"`
+	// Player's ID.
+	UID OptUUID `json:"uid"`
+	// Player's generated nickname.
+	Nickname OptString `json:"nickname"`
+	// Player's ELO rating.
+	Rating OptInt64 `json:"rating"`
+	// Player's total EXP.
+	Exp OptInt64 `json:"exp"`
+}
+
+// GetRank returns the value of Rank.
+func (s *LeaderboardEntry) GetRank() OptInt {
+	return s.Rank
+}
+
+// GetUID returns the value of UID.
+func (s *LeaderboardEntry) GetUID() OptUUID {
+	return s.UID
+}
+
+// GetNickname returns the value of Nickname.
+func (s *LeaderboardEntry) GetNickname() OptString {
+	return s.Nickname
+}
+
+// GetRating returns the value of Rating.
+func (s *LeaderboardEntry) GetRating() OptInt64 {
+	return s.Rating
+}
+
+// GetExp returns the value of Exp.
+func (s *LeaderboardEntry) GetExp() OptInt64 {
+	return s.Exp
+}
+
+// SetRank sets the value of Rank.
+func (s *LeaderboardEntry) SetRank(val OptInt) {
+	s.Rank = val
+}
+
+// SetUID sets the value of UID.
+func (s *LeaderboardEntry) SetUID(val OptUUID) {
+	s.UID = val
+}
+
+// SetNickname sets the value of Nickname.
+func (s *LeaderboardEntry) SetNickname(val OptString) {
+	s.Nickname = val
+}
+
+// SetRating sets the value of Rating.
+func (s *LeaderboardEntry) SetRating(val OptInt64) {
+	s.Rating = val
+}
+
+// SetExp sets the value of Exp.
+func (s *LeaderboardEntry) SetExp(val OptInt64) {
+	s.Exp = val
+}
+
+// Ref: #/components/schemas/LeaderboardResponse
+type LeaderboardResponse struct {
+	// Leaderboard period.
+	Period OptLeaderboardResponsePeriod `json:"period"`
+	// Sort field.
+	Sort OptLeaderboardResponseSort `json:"sort"`
+	// Unix timestamp in milliseconds when the leaderboard was generated.
+	GeneratedAt OptInt64 `json:"generated_at"`
+	// Leaderboard entries ordered by rank.
+	Players []LeaderboardEntry `json:"players"`
+}
+
+// GetPeriod returns the value of Period.
+func (s *LeaderboardResponse) GetPeriod() OptLeaderboardResponsePeriod {
+	return s.Period
+}
+
+// GetSort returns the value of Sort.
+func (s *LeaderboardResponse) GetSort() OptLeaderboardResponseSort {
+	return s.Sort
+}
+
+// GetGeneratedAt returns the value of GeneratedAt.
+func (s *LeaderboardResponse) GetGeneratedAt() OptInt64 {
+	return s.GeneratedAt
+}
+
+// GetPlayers returns the value of Players.
+func (s *LeaderboardResponse) GetPlayers() []LeaderboardEntry {
+	return s.Players
+}
+
+// SetPeriod sets the value of Period.
+func (s *LeaderboardResponse) SetPeriod(val OptLeaderboardResponsePeriod) {
+	s.Period = val
+}
+
+// SetSort sets the value of Sort.
+func (s *LeaderboardResponse) SetSort(val OptLeaderboardResponseSort) {
+	s.Sort = val
+}
+
+// SetGeneratedAt sets the value of GeneratedAt.
+func (s *LeaderboardResponse) SetGeneratedAt(val OptInt64) {
+	s.GeneratedAt = val
+}
+
+// SetPlayers sets the value of Players.
+func (s *LeaderboardResponse) SetPlayers(val []LeaderboardEntry) {
+	s.Players = val
+}
+
+func (*LeaderboardResponse) getLeaderboardRes() {}
+
+// Leaderboard period.
+type LeaderboardResponsePeriod string
+
+const (
+	LeaderboardResponsePeriodWeek  LeaderboardResponsePeriod = "week"
+	LeaderboardResponsePeriodMonth LeaderboardResponsePeriod = "month"
+)
+
+// AllValues returns all LeaderboardResponsePeriod values.
+func (LeaderboardResponsePeriod) AllValues() []LeaderboardResponsePeriod {
+	return []LeaderboardResponsePeriod{
+		LeaderboardResponsePeriodWeek,
+		LeaderboardResponsePeriodMonth,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s LeaderboardResponsePeriod) MarshalText() ([]byte, error) {
+	switch s {
+	case LeaderboardResponsePeriodWeek:
+		return []byte(s), nil
+	case LeaderboardResponsePeriodMonth:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *LeaderboardResponsePeriod) UnmarshalText(data []byte) error {
+	switch LeaderboardResponsePeriod(data) {
+	case LeaderboardResponsePeriodWeek:
+		*s = LeaderboardResponsePeriodWeek
+		return nil
+	case LeaderboardResponsePeriodMonth:
+		*s = LeaderboardResponsePeriodMonth
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Sort field.
+type LeaderboardResponseSort string
+
+const (
+	LeaderboardResponseSortRating LeaderboardResponseSort = "rating"
+	LeaderboardResponseSortExp    LeaderboardResponseSort = "exp"
+)
+
+// AllValues returns all LeaderboardResponseSort values.
+func (LeaderboardResponseSort) AllValues() []LeaderboardResponseSort {
+	return []LeaderboardResponseSort{
+		LeaderboardResponseSortRating,
+		LeaderboardResponseSortExp,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s LeaderboardResponseSort) MarshalText() ([]byte, error) {
+	switch s {
+	case LeaderboardResponseSortRating:
+		return []byte(s), nil
+	case LeaderboardResponseSortExp:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *LeaderboardResponseSort) UnmarshalText(data []byte) error {
+	switch LeaderboardResponseSort(data) {
+	case LeaderboardResponseSortRating:
+		*s = LeaderboardResponseSortRating
+		return nil
+	case LeaderboardResponseSortExp:
+		*s = LeaderboardResponseSortExp
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
 
 // Ref: #/components/schemas/ListGamesResponse
 type ListGamesResponse struct {
@@ -937,6 +1229,52 @@ func (o OptGameSummary) Or(d GameSummary) GameSummary {
 	return d
 }
 
+// NewOptGetLeaderboardSort returns new OptGetLeaderboardSort with value set to v.
+func NewOptGetLeaderboardSort(v GetLeaderboardSort) OptGetLeaderboardSort {
+	return OptGetLeaderboardSort{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptGetLeaderboardSort is optional GetLeaderboardSort.
+type OptGetLeaderboardSort struct {
+	Value GetLeaderboardSort
+	Set   bool
+}
+
+// IsSet returns true if OptGetLeaderboardSort was set.
+func (o OptGetLeaderboardSort) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptGetLeaderboardSort) Reset() {
+	var v GetLeaderboardSort
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptGetLeaderboardSort) SetTo(v GetLeaderboardSort) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptGetLeaderboardSort) Get() (v GetLeaderboardSort, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptGetLeaderboardSort) Or(d GetLeaderboardSort) GetLeaderboardSort {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptInt returns new OptInt with value set to v.
 func NewOptInt(v int) OptInt {
 	return OptInt{
@@ -1023,6 +1361,98 @@ func (o OptInt64) Get() (v int64, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptInt64) Or(d int64) int64 {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptLeaderboardResponsePeriod returns new OptLeaderboardResponsePeriod with value set to v.
+func NewOptLeaderboardResponsePeriod(v LeaderboardResponsePeriod) OptLeaderboardResponsePeriod {
+	return OptLeaderboardResponsePeriod{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptLeaderboardResponsePeriod is optional LeaderboardResponsePeriod.
+type OptLeaderboardResponsePeriod struct {
+	Value LeaderboardResponsePeriod
+	Set   bool
+}
+
+// IsSet returns true if OptLeaderboardResponsePeriod was set.
+func (o OptLeaderboardResponsePeriod) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptLeaderboardResponsePeriod) Reset() {
+	var v LeaderboardResponsePeriod
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptLeaderboardResponsePeriod) SetTo(v LeaderboardResponsePeriod) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptLeaderboardResponsePeriod) Get() (v LeaderboardResponsePeriod, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptLeaderboardResponsePeriod) Or(d LeaderboardResponsePeriod) LeaderboardResponsePeriod {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptLeaderboardResponseSort returns new OptLeaderboardResponseSort with value set to v.
+func NewOptLeaderboardResponseSort(v LeaderboardResponseSort) OptLeaderboardResponseSort {
+	return OptLeaderboardResponseSort{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptLeaderboardResponseSort is optional LeaderboardResponseSort.
+type OptLeaderboardResponseSort struct {
+	Value LeaderboardResponseSort
+	Set   bool
+}
+
+// IsSet returns true if OptLeaderboardResponseSort was set.
+func (o OptLeaderboardResponseSort) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptLeaderboardResponseSort) Reset() {
+	var v LeaderboardResponseSort
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptLeaderboardResponseSort) SetTo(v LeaderboardResponseSort) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptLeaderboardResponseSort) Get() (v LeaderboardResponseSort, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptLeaderboardResponseSort) Or(d LeaderboardResponseSort) LeaderboardResponseSort {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/internal/server/ogen/oas_server_gen.go
+++ b/internal/server/ogen/oas_server_gen.go
@@ -34,6 +34,13 @@ type Handler interface {
 	//
 	// POST /games/with-bot
 	CreateGameWithBot(ctx context.Context) (CreateGameWithBotRes, error)
+	// GetLeaderboard implements getLeaderboard operation.
+	//
+	// Returns the top players by current rating or total EXP who were active during the requested period.
+	// Results are cached for 5 minutes.
+	//
+	// GET /leaderboard
+	GetLeaderboard(ctx context.Context, params GetLeaderboardParams) (GetLeaderboardRes, error)
 	// GetPlayerStateUID implements getPlayerStateUID operation.
 	//
 	// Get user state.

--- a/internal/server/ogen/oas_unimplemented_gen.go
+++ b/internal/server/ogen/oas_unimplemented_gen.go
@@ -51,6 +51,16 @@ func (UnimplementedHandler) CreateGameWithBot(ctx context.Context) (r CreateGame
 	return r, ht.ErrNotImplemented
 }
 
+// GetLeaderboard implements getLeaderboard operation.
+//
+// Returns the top players by current rating or total EXP who were active during the requested period.
+// Results are cached for 5 minutes.
+//
+// GET /leaderboard
+func (UnimplementedHandler) GetLeaderboard(ctx context.Context, params GetLeaderboardParams) (r GetLeaderboardRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // GetPlayerStateUID implements getPlayerStateUID operation.
 //
 // Get user state.

--- a/internal/server/ogen/oas_validators_gen.go
+++ b/internal/server/ogen/oas_validators_gen.go
@@ -221,6 +221,28 @@ func (s *GameSummary) Validate() error {
 	return nil
 }
 
+func (s GetLeaderboardPeriod) Validate() error {
+	switch s {
+	case "week":
+		return nil
+	case "month":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s GetLeaderboardSort) Validate() error {
+	switch s {
+	case "rating":
+		return nil
+	case "exp":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s *JoinGameResponse) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -274,6 +296,76 @@ func (s *JoinGameResponse) Validate() error {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s *LeaderboardResponse) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.Period.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "period",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.Sort.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "sort",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s LeaderboardResponsePeriod) Validate() error {
+	switch s {
+	case "week":
+		return nil
+	case "month":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s LeaderboardResponseSort) Validate() error {
+	switch s {
+	case "rating":
+		return nil
+	case "exp":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *ListGamesResponse) Validate() error {

--- a/internal/server/restapi/handlers/leaderboard.go
+++ b/internal/server/restapi/handlers/leaderboard.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/rustwizard/balda/internal/leaderboard"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+)
+
+// GetLeaderboard implements baldaapi.Handler.
+func (h *Handlers) GetLeaderboard(ctx context.Context, params baldaapi.GetLeaderboardParams) (baldaapi.GetLeaderboardRes, error) {
+	sortBy := "rating"
+	if params.Sort.IsSet() {
+		sortBy = string(params.Sort.Value)
+	}
+
+	limit := 100
+	if params.Limit.IsSet() {
+		limit = params.Limit.Value
+	}
+
+	entries, generatedAt, err := h.svc.GetLeaderboard(ctx, leaderboard.Request{
+		Period: string(params.Period),
+		Sort:   sortBy,
+		Limit:  limit,
+	})
+	if err != nil {
+		slog.Error("get leaderboard", slog.Any("error", err))
+		return &baldaapi.GetLeaderboardInternalServerError{
+			Status:  baldaapi.NewOptInt(http.StatusInternalServerError),
+			Message: baldaapi.NewOptString("failed to get leaderboard"),
+			Type:    baldaapi.NewOptString("InternalServerError"),
+		}, nil
+	}
+
+	players := make([]baldaapi.LeaderboardEntry, len(entries))
+	for i, e := range entries {
+		players[i] = baldaapi.LeaderboardEntry{
+			Rank:     baldaapi.NewOptInt(i + 1),
+			UID:      baldaapi.NewOptUUID(e.PlayerID),
+			Nickname: baldaapi.NewOptString(e.Nickname),
+			Rating:   baldaapi.NewOptInt64(e.Rating),
+			Exp:      baldaapi.NewOptInt64(e.Exp),
+		}
+	}
+
+	return &baldaapi.LeaderboardResponse{
+		Period:      baldaapi.NewOptLeaderboardResponsePeriod(baldaapi.LeaderboardResponsePeriod(params.Period)),
+		Sort:        baldaapi.NewOptLeaderboardResponseSort(baldaapi.LeaderboardResponseSort(sortBy)),
+		GeneratedAt: baldaapi.NewOptInt64(generatedAt.UnixMilli()),
+		Players:     players,
+	}, nil
+}

--- a/internal/service/balda_service.go
+++ b/internal/service/balda_service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rustwizard/balda/internal/game"
+	"github.com/rustwizard/balda/internal/leaderboard"
 	"github.com/rustwizard/balda/internal/lobby"
 	"github.com/rustwizard/balda/internal/matchmaking"
 	"github.com/rustwizard/balda/internal/storage"
@@ -21,10 +22,11 @@ type Balda struct {
 	lby *lobby.Lobby
 	mm  *matchmaking.Queue
 	s   *storage.Balda
+	lb  *leaderboard.Service
 }
 
-func New(lby *lobby.Lobby, mm *matchmaking.Queue, s *storage.Balda) *Balda {
-	return &Balda{lby: lby, mm: mm, s: s}
+func New(lby *lobby.Lobby, mm *matchmaking.Queue, s *storage.Balda, lb *leaderboard.Service) *Balda {
+	return &Balda{lby: lby, mm: mm, s: s, lb: lb}
 }
 
 func (s *Balda) GameSummary(playerID string) *lobby.GameSummary {
@@ -69,6 +71,11 @@ func (s *Balda) CreateUser(ctx context.Context, firstname, lastname, email, pass
 // GetPlayerState returns the profile fields for the given player UUID.
 func (s *Balda) GetPlayerState(ctx context.Context, playerID uuid.UUID) (storage.PlayerState, error) {
 	return s.s.GetPlayerState(ctx, playerID)
+}
+
+// GetLeaderboard returns the leaderboard for the requested period and sort order.
+func (s *Balda) GetLeaderboard(ctx context.Context, req leaderboard.Request) ([]leaderboard.Entry, time.Time, error) {
+	return s.lb.GetLeaderboard(ctx, req)
 }
 
 // GetUserForToken returns the player UUID and role needed to mint an access token.

--- a/internal/storage/leaderboard.go
+++ b/internal/storage/leaderboard.go
@@ -1,0 +1,64 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	leaderboardSortRating = "rating"
+	leaderboardSortExp    = "exp"
+)
+
+// LeaderboardEntry is one row in a leaderboard.
+type LeaderboardEntry struct {
+	PlayerID  uuid.UUID
+	Nickname  string
+	Rating    int64
+	Exp       int64
+	UpdatedAt time.Time
+}
+
+// GetLeaderboard returns the top players active since periodStart, ordered by sortBy.
+// sortBy must be validated by the caller; only "rating" or "exp" are accepted.
+func (b *Balda) GetLeaderboard(ctx context.Context, periodStart time.Time, sortBy string, limit int) ([]LeaderboardEntry, error) {
+	ctx, cancel := context.WithTimeout(ctx, b.t)
+	defer cancel()
+
+	orderCol := leaderboardSortRating
+	tieCol := leaderboardSortExp
+	if sortBy == leaderboardSortExp {
+		orderCol = leaderboardSortExp
+		tieCol = leaderboardSortRating
+	}
+
+	query := fmt.Sprintf(`
+		SELECT player_id, nickname, rating, exp, updated_at
+		FROM player_state
+		WHERE updated_at >= $1
+		ORDER BY %s DESC, %s DESC, player_id ASC
+		LIMIT $2
+	`, orderCol, tieCol)
+
+	rows, err := b.db.Query(ctx, query, periodStart, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get leaderboard: %w", err)
+	}
+	defer rows.Close()
+
+	var out []LeaderboardEntry
+	for rows.Next() {
+		var e LeaderboardEntry
+		if err := rows.Scan(&e.PlayerID, &e.Nickname, &e.Rating, &e.Exp, &e.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("get leaderboard scan: %w", err)
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get leaderboard rows: %w", err)
+	}
+	return out, nil
+}

--- a/migrations/007_add_leaderboard_indexes.up.sql
+++ b/migrations/007_add_leaderboard_indexes.up.sql
@@ -1,0 +1,14 @@
+CREATE INDEX IF NOT EXISTS idx_player_state_rating_updated
+    ON player_state (rating DESC, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_player_state_exp_updated
+    ON player_state (exp DESC, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_player_state_updated_at
+    ON player_state (updated_at DESC);
+
+---- create above / drop below ----
+
+DROP INDEX IF EXISTS idx_player_state_rating_updated;
+DROP INDEX IF EXISTS idx_player_state_exp_updated;
+DROP INDEX IF EXISTS idx_player_state_updated_at;

--- a/tests/handlers_test.go
+++ b/tests/handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rustwizard/balda/internal/auth"
 	"github.com/rustwizard/balda/internal/centrifugo"
 	"github.com/rustwizard/balda/internal/game"
+	"github.com/rustwizard/balda/internal/leaderboard"
 	"github.com/rustwizard/balda/internal/lobby"
 	"github.com/rustwizard/balda/internal/matchmaking"
 	"github.com/rustwizard/balda/internal/presence"
@@ -62,6 +63,8 @@ type coreSetup struct {
 	svc     *service.Balda
 	pres    *presence.Service
 	lby     *lobby.Lobby
+	s       *storage.Balda
+	rdb     *redis.Client
 	cleanup func()
 }
 
@@ -126,12 +129,15 @@ func setupCore(ctx context.Context, t *testing.T) *coreSetup {
 	})
 
 	s := storage.New(pool, 10*time.Second)
-	svc := service.New(lby, mm, s)
+	lb := leaderboard.NewService(s, rdb, 5*time.Minute)
+	svc := service.New(lby, mm, s, lb)
 
 	return &coreSetup{
 		svc:  svc,
 		pres: pres,
 		lby:  lby,
+		s:    s,
+		rdb:  rdb,
 		cleanup: func() {
 			pool.Close()
 			pgCleanup()

--- a/tests/leaderboard_test.go
+++ b/tests/leaderboard_test.go
@@ -1,0 +1,172 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/rustwizard/balda/internal/centrifugo"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+	"github.com/rustwizard/balda/internal/server/restapi/handlers"
+	"github.com/rustwizard/balda/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupLeaderboard returns a handler, storage and cleanup for leaderboard tests.
+func setupLeaderboard(t *testing.T) (*handlers.Handlers, *storage.Balda, *redis.Client, func()) {
+	t.Helper()
+	ctx := context.Background()
+	core := setupCore(ctx, t)
+	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret")
+	return h, core.s, core.rdb, core.cleanup
+}
+
+// seedLeaderboardPlayer inserts a user + player_state row with specific rating/exp and updated_at.
+func seedLeaderboardPlayer(ctx context.Context, t *testing.T, s *storage.Balda, email string, rating int, exp int64, updatedAt time.Time) uuid.UUID {
+	t.Helper()
+	playerID := uuid.New()
+	var userID int64
+	err := s.Pool().QueryRow(ctx,
+		`INSERT INTO users (first_name, last_name, email, hash_password) VALUES ('Test', 'User', $1, 'x') RETURNING user_id`,
+		email,
+	).Scan(&userID)
+	require.NoError(t, err)
+
+	_, err = s.Pool().Exec(ctx,
+		`INSERT INTO player_state (user_id, player_id, nickname, exp, rating, flags, lives, updated_at) VALUES ($1, $2, $3, $4, $5, 0, 5, $6)`,
+		userID, playerID, email, exp, rating, updatedAt,
+	)
+	require.NoError(t, err)
+	return playerID
+}
+
+func TestGetLeaderboard(t *testing.T) {
+	ctx := context.Background()
+	h, s, _, cleanup := setupLeaderboard(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	// Active players within the period.
+	p1 := seedLeaderboardPlayer(ctx, t, s, "lb.p1@example.org", 1500, 3000, now.Add(-1*time.Hour))
+	p2 := seedLeaderboardPlayer(ctx, t, s, "lb.p2@example.org", 1400, 4000, now.Add(-2*time.Hour))
+	p3 := seedLeaderboardPlayer(ctx, t, s, "lb.p3@example.org", 1300, 5000, now.Add(-3*time.Hour))
+	// Inactive player outside the period.
+	seedLeaderboardPlayer(ctx, t, s, "lb.old@example.org", 2000, 9000, now.Add(-40*24*time.Hour))
+
+	t.Run("top by rating", func(t *testing.T) {
+		res, err := h.GetLeaderboard(ctx, baldaapi.GetLeaderboardParams{
+			Period: baldaapi.GetLeaderboardPeriodWeek,
+			Sort:   baldaapi.NewOptGetLeaderboardSort(baldaapi.GetLeaderboardSortRating),
+			Limit:  baldaapi.NewOptInt(10),
+		})
+		require.NoError(t, err)
+
+		ok, isOK := res.(*baldaapi.LeaderboardResponse)
+		require.True(t, isOK, "expected *LeaderboardResponse, got %T", res)
+		require.Len(t, ok.Players, 3)
+
+		assert.Equal(t, 1, ok.Players[0].Rank.Value)
+		assert.Equal(t, p1, ok.Players[0].UID.Value)
+		assert.EqualValues(t, 1500, ok.Players[0].Rating.Value)
+
+		assert.Equal(t, 2, ok.Players[1].Rank.Value)
+		assert.Equal(t, p2, ok.Players[1].UID.Value)
+
+		assert.Equal(t, 3, ok.Players[2].Rank.Value)
+		assert.Equal(t, p3, ok.Players[2].UID.Value)
+	})
+
+	t.Run("top by exp", func(t *testing.T) {
+		res, err := h.GetLeaderboard(ctx, baldaapi.GetLeaderboardParams{
+			Period: baldaapi.GetLeaderboardPeriodWeek,
+			Sort:   baldaapi.NewOptGetLeaderboardSort(baldaapi.GetLeaderboardSortExp),
+			Limit:  baldaapi.NewOptInt(10),
+		})
+		require.NoError(t, err)
+
+		ok, isOK := res.(*baldaapi.LeaderboardResponse)
+		require.True(t, isOK, "expected *LeaderboardResponse, got %T", res)
+		require.Len(t, ok.Players, 3)
+
+		assert.Equal(t, p3, ok.Players[0].UID.Value)
+		assert.Equal(t, p2, ok.Players[1].UID.Value)
+		assert.Equal(t, p1, ok.Players[2].UID.Value)
+	})
+
+	t.Run("limit caps result", func(t *testing.T) {
+		res, err := h.GetLeaderboard(ctx, baldaapi.GetLeaderboardParams{
+			Period: baldaapi.GetLeaderboardPeriodWeek,
+			Sort:   baldaapi.NewOptGetLeaderboardSort(baldaapi.GetLeaderboardSortRating),
+			Limit:  baldaapi.NewOptInt(2),
+		})
+		require.NoError(t, err)
+
+		ok, isOK := res.(*baldaapi.LeaderboardResponse)
+		require.True(t, isOK, "expected *LeaderboardResponse, got %T", res)
+		require.Len(t, ok.Players, 2)
+	})
+}
+
+func TestLeaderboardCache(t *testing.T) {
+	ctx := context.Background()
+	h, s, rdb, cleanup := setupLeaderboard(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	p1 := seedLeaderboardPlayer(ctx, t, s, "lb.cache@example.org", 1500, 3000, now.Add(-1*time.Hour))
+
+	req := baldaapi.GetLeaderboardParams{
+		Period: baldaapi.GetLeaderboardPeriodWeek,
+		Sort:   baldaapi.NewOptGetLeaderboardSort(baldaapi.GetLeaderboardSortRating),
+		Limit:  baldaapi.NewOptInt(10),
+	}
+
+	// First call should populate cache.
+	_, err := h.GetLeaderboard(ctx, req)
+	require.NoError(t, err)
+
+	key := "leaderboard:week:rating:10"
+	cached, err := rdb.Get(ctx, key).Result()
+	require.NoError(t, err)
+	assert.Contains(t, cached, p1.String())
+
+	ttl, err := rdb.PTTL(ctx, key).Result()
+	require.NoError(t, err)
+	assert.Greater(t, ttl, time.Duration(0))
+
+	// Second call should return cached data (we verify by checking the same key still exists).
+	_, err = h.GetLeaderboard(ctx, req)
+	require.NoError(t, err)
+	cached2, err := rdb.Get(ctx, key).Result()
+	require.NoError(t, err)
+	assert.Equal(t, cached, cached2)
+}
+
+func TestLeaderboardHTTP(t *testing.T) {
+	ctx := context.Background()
+	h, s, _, cleanup := setupLeaderboard(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	seedLeaderboardPlayer(ctx, t, s, "lb.http@example.org", 1500, 3000, now.Add(-1*time.Hour))
+
+	srv, err := baldaapi.NewServer(h, h, baldaapi.WithPathPrefix("/balda/api/v1"))
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/balda/api/v1/leaderboard?period=week&sort=rating&limit=10", http.NoBody)
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "lb.http")
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/balda/api/v1/leaderboard?period=invalid", http.NoBody)
+	srv.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}


### PR DESCRIPTION
Add GET /leaderboard with weekly/monthly periods, rating/exp sorting, Redis caching (TTL 5m), and integration tests.

Changes:
- OpenAPI: GET /leaderboard path, LeaderboardResponse/Entry schemas
- Migrations: indexes on player_state for leaderboard queries
- Storage: GetLeaderboard query
- internal/leaderboard: service with Redis cache and validation
- service.Balda: delegate to leaderboard service
- cmd/server.go: wire leaderboard service
- handlers: GetLeaderboard implementation
- tests: leaderboard handler, HTTP, cache tests