### PR TITLE
feat: player statistics endpoint and lobby stats modal

### DIFF
--- a/api/openapi/http-api.yaml
+++ b/api/openapi/http-api.yaml
@@ -561,6 +561,30 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
 
+  /player/stats:
+    get:
+      operationId: getPlayerStats
+      summary: Get player statistics
+      description: |
+        Returns lifetime aggregated statistics for the currently
+        authenticated player: games played, wins/losses/draws, win rate,
+        average word length, best word and favorite letter.
+      tags:
+        - Player
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Player statistics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlayerStatsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
 components:
   securitySchemes:
     BearerAuth:
@@ -1158,6 +1182,48 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Achievement"
+
+    PlayerStatsResponse:
+      type: object
+      properties:
+        games_played:
+          description: Total number of finished games
+          example: 42
+          type: integer
+          format: int64
+        wins:
+          description: Number of games won
+          example: 20
+          type: integer
+          format: int64
+        losses:
+          description: Number of games lost
+          example: 18
+          type: integer
+          format: int64
+        draws:
+          description: Number of games ended in a draw
+          example: 4
+          type: integer
+          format: int64
+        win_rate:
+          description: Win rate as a fraction (0..1)
+          example: 0.476
+          type: number
+          format: double
+        avg_word_length:
+          description: Average length of submitted words in letters
+          example: 4.35
+          type: number
+          format: double
+        best_word:
+          description: Longest word ever submitted (empty if no games with recorded words)
+          example: автостоп
+          type: string
+        favorite_letter:
+          description: Most frequently used letter across all submitted words (empty if none)
+          example: а
+          type: string
 
     Achievement:
       type: object

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -338,11 +338,21 @@ Centrifugo уже есть — достаточно добавить канал 
 **Предложение:** добавить таблицу `game_moves` (game_id, move_number, player_id, letter, word, coords)
 и эндпоинт `GET /games/{id}/replay`. Запись хода в `SubmitWord`.
 
-### 34. Статистика игрока (P3)
+### 34. ✅ Статистика игрока (P3)
 **Затрагивает:** `internal/storage/`, REST API, фронт
 
-Средняя длина слова, лучшее слово, винрейт, любимая буква. Аггрегировать из `game_result_players`
-или добавить материализованную статистику в `player_state`.
+Средняя длина слова, лучшее слово, винрейт, любимая буква. Аггрегируется на лету из
+`game_result_players` (без материализованной статистики в `player_state`).
+
+**Сделано:**
+- Миграция `010_game_result_words.up.sql`: колонка `words jsonb` в `game_result_players`;
+  `storage.SaveGameResult` сохраняет слова игрока (из `game.PlayerState.Words`).
+- `storage.GetPlayerStats`: игры/победы/поражения/ничьи, винрейт, средняя длина слова
+  (из `SUM(score)/SUM(words_count)` — работает и для старых игр без `words`), лучшее
+  слово и любимая буква (по сохранённым словам; `ё` приравнена к `е`).
+- Эндпоинт `GET /player/stats` (BearerAuth, по JWT-claims — как `/player/achievements`),
+  схема `PlayerStatsResponse`.
+- Фронт: `StatsModal.svelte` с метриками, кнопка 📊 в лобби рядом с достижениями.
 
 ### Механики доски
 

--- a/frontend/src/components/Lobby.svelte
+++ b/frontend/src/components/Lobby.svelte
@@ -4,11 +4,13 @@
   import { gameState } from '../stores/game.svelte';
   import { achievements } from '../stores/achievements.svelte';
   import AchievementsModal from './AchievementsModal.svelte';
+  import StatsModal from './StatsModal.svelte';
 
   let subscribed = $state(false);
   let error = $state('');
   let loading = $state(false);
   let showAchievements = $state(false);
+  let showStats = $state(false);
 
   async function create() {
     loading = true;
@@ -110,6 +112,14 @@
       >
         🏆 {achievements.unlockedCount}/{achievements.totalCount}
       </button>
+      <button
+        type="button"
+        onclick={() => (showStats = true)}
+        class="rounded-lg bg-blue-100 px-2 py-1 text-sm font-semibold text-blue-700 hover:bg-blue-200"
+        aria-label="Статистика"
+      >
+        📊
+      </button>
       <div class="text-sm font-medium text-stone-600">
         {gameState.nickname}
         <span class="ml-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-700">{gameState.exp} XP</span>
@@ -169,4 +179,8 @@
 
 {#if showAchievements}
   <AchievementsModal onClose={() => (showAchievements = false)} />
+{/if}
+
+{#if showStats}
+  <StatsModal onClose={() => (showStats = false)} />
 {/if}

--- a/frontend/src/components/StatsModal.svelte
+++ b/frontend/src/components/StatsModal.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import { getPlayerStats } from '../lib/api';
+  import type { PlayerStats } from '../types';
+
+  interface Props {
+    onClose: () => void;
+  }
+
+  let { onClose }: Props = $props();
+
+  let stats = $state<PlayerStats | null>(null);
+  let loading = $state(true);
+  let error = $state('');
+
+  $effect(() => {
+    getPlayerStats()
+      .then((s) => (stats = s))
+      .catch((e) => (error = e instanceof Error ? e.message : 'Не удалось загрузить статистику'))
+      .finally(() => (loading = false));
+  });
+
+  function plural(n: number, one: string, few: string, many: string): string {
+    const mod100 = Math.abs(n) % 100;
+    const mod10 = mod100 % 10;
+    if (mod100 > 10 && mod100 < 20) return many;
+    if (mod10 > 1 && mod10 < 5) return few;
+    if (mod10 === 1) return one;
+    return many;
+  }
+</script>
+
+<div
+  class="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Статистика"
+  tabindex="-1"
+  onclick={(e) => e.target === e.currentTarget && onClose()}
+  onkeydown={(e) => e.key === 'Escape' && onClose()}
+>
+  <div class="mx-auto w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+    <div class="mb-4 flex items-center justify-between">
+      <h2 class="text-2xl font-bold text-stone-800">Статистика</h2>
+      <button
+        type="button"
+        class="text-stone-400 hover:text-stone-600"
+        onclick={onClose}
+        aria-label="Закрыть"
+      >
+        ✕
+      </button>
+    </div>
+
+    {#if loading}
+      <div class="py-8 text-center text-stone-500">Загрузка…</div>
+    {:else if error}
+      <div class="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+        {error}
+      </div>
+    {:else if stats}
+      {#if stats.games_played === 0}
+        <div class="py-8 text-center text-stone-500">Пока нет сыгранных игр</div>
+      {:else}
+        <div class="grid grid-cols-3 gap-2 text-center">
+          <div class="rounded-xl bg-stone-50 p-3">
+            <div class="text-xl font-extrabold text-stone-800">{stats.games_played}</div>
+            <div class="text-xs text-stone-500">{plural(stats.games_played, 'игра', 'игры', 'игр')}</div>
+          </div>
+          <div class="rounded-xl bg-green-50 p-3">
+            <div class="text-xl font-extrabold text-green-700">{stats.wins}</div>
+            <div class="text-xs text-stone-500">{plural(stats.wins, 'победа', 'победы', 'побед')}</div>
+          </div>
+          <div class="rounded-xl bg-red-50 p-3">
+            <div class="text-xl font-extrabold text-red-600">{stats.losses}</div>
+            <div class="text-xs text-stone-500">{plural(stats.losses, 'поражение', 'поражения', 'поражений')}</div>
+          </div>
+        </div>
+
+        <div class="mt-2 grid grid-cols-3 gap-2 text-center">
+          <div class="rounded-xl bg-stone-50 p-3">
+            <div class="text-xl font-extrabold text-stone-800">{stats.draws}</div>
+            <div class="text-xs text-stone-500">{plural(stats.draws, 'ничья', 'ничьи', 'ничьих')}</div>
+          </div>
+          <div class="rounded-xl bg-blue-50 p-3">
+            <div class="text-xl font-extrabold text-blue-700">{Math.round(stats.win_rate * 100)}%</div>
+            <div class="text-xs text-stone-500">винрейт</div>
+          </div>
+          <div class="rounded-xl bg-stone-50 p-3">
+            <div class="text-xl font-extrabold text-stone-800">{stats.avg_word_length.toFixed(1)}</div>
+            <div class="text-xs text-stone-500">ср. длина слова</div>
+          </div>
+        </div>
+
+        <div class="mt-2 grid grid-cols-2 gap-2 text-center">
+          <div class="rounded-xl bg-yellow-50 p-3">
+            <div class="truncate text-xl font-extrabold text-yellow-700">{stats.best_word || '—'}</div>
+            <div class="text-xs text-stone-500">лучшее слово</div>
+          </div>
+          <div class="rounded-xl bg-amber-50 p-3">
+            <div class="text-xl font-extrabold uppercase text-amber-700">{stats.favorite_letter || '—'}</div>
+            <div class="text-xs text-stone-500">любимая буква</div>
+          </div>
+        </div>
+      {/if}
+    {/if}
+  </div>
+</div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   MoveRequest,
   MoveResponse,
   PlayerAchievementsResponse,
+  PlayerStats,
 } from '../types';
 
 const API_BASE = '/balda/api/v1';
@@ -169,4 +170,8 @@ export function rejectEnd(gameId: string): Promise<void> {
 
 export function getPlayerAchievements(): Promise<PlayerAchievementsResponse> {
   return apiFetch('/player/achievements', { method: 'GET' });
+}
+
+export function getPlayerStats(): Promise<PlayerStats> {
+  return apiFetch('/player/stats', { method: 'GET' });
 }

--- a/frontend/src/stores/game.svelte.ts
+++ b/frontend/src/stores/game.svelte.ts
@@ -199,6 +199,9 @@ export function createGameState() {
         winnerUid = ev.winner_uid;
         finishReason = ev.reason;
         players = ev.players.map(mergePlayerState);
+        // The final move never triggers a game_state event, so the last
+        // letter only arrives inside game_over.
+        if (ev.board) board = ev.board;
     }
 
     function applyEndProposal(ev: EvEndProposal) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -213,6 +213,17 @@ export interface PlayerAchievementsResponse {
     achievements: Achievement[];
 }
 
+export interface PlayerStats {
+    games_played: number;
+    wins: number;
+    losses: number;
+    draws: number;
+    win_rate: number;
+    avg_word_length: number;
+    best_word: string;
+    favorite_letter: string;
+}
+
 export interface EvAchievementUnlocked {
     type: "achievement_unlocked";
     game_id: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -121,6 +121,7 @@ export interface EvGameOver {
     winner_uid?: string | null;
     players: PlayerGameState[];
     reason?: "kick" | "game_finished" | "accept_end";
+    board?: string[][];
 }
 
 export interface EvGameCreated {

--- a/internal/centrifugo/events.go
+++ b/internal/centrifugo/events.go
@@ -97,6 +97,10 @@ type EvGameOver struct {
 	WinnerUID string        `json:"winner_uid,omitempty"`
 	Players   []PlayerState `json:"players"`
 	Reason    string        `json:"reason,omitempty"`
+	// Board is the final board snapshot: on a natural finish the last move
+	// never triggers a game_state event, so without it clients would not see
+	// the final letter.
+	Board [5][5]string `json:"board"`
 }
 
 // EvEndProposal is published when the current player proposes to end the game.

--- a/internal/gamecoord/coord.go
+++ b/internal/gamecoord/coord.go
@@ -234,6 +234,7 @@ func (c *Coordinator) dispatchGameResult(winnerUID string, reason storage.Finish
 			WordsCount:     s.WordsCount,
 			ExpGained:      storage.ExpGained(s.Score, isWinner, isDraw),
 			BestWordLength: bestWordLength(s.Words),
+			Words:          s.Words,
 		}
 	}
 	result := storage.GameResult{

--- a/internal/gamecoord/coord.go
+++ b/internal/gamecoord/coord.go
@@ -203,6 +203,7 @@ func (c *Coordinator) publishEndProposalResult(accepted bool, remainingMs int64)
 			WinnerUID: winnerUID,
 			Players:   players,
 			Reason:    "accept_end",
+			Board:     c.g.BoardSnapshot(),
 		}
 		if err := c.cf.Publish(ctx, centrifugo.ChannelGame(c.gameID), gameOverEv); err != nil {
 			slog.Error("gamecoord: publish game_over (accept_end)", slog.String("gameID", c.gameID), slog.Any("error", err))
@@ -329,6 +330,7 @@ func (c *Coordinator) publishNaturalGameOver() {
 		WinnerUID: winnerUID,
 		Players:   players,
 		Reason:    "game_finished",
+		Board:     c.g.BoardSnapshot(),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -363,6 +365,7 @@ func (c *Coordinator) publishGameOver(kickedPlayerID string) {
 		WinnerUID: winnerUID,
 		Players:   players,
 		Reason:    "kick",
+		Board:     c.g.BoardSnapshot(),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/gamecoord/coord_test.go
+++ b/internal/gamecoord/coord_test.go
@@ -100,7 +100,67 @@ func TestFindWinnerByScore(t *testing.T) {
 	}
 }
 
-// TestPublishGameOver_PersistsBeforePublish verifies that onGameOver is invoked
+// TestPublishGameOver_IncludesBoard verifies that the game_over event carries
+// the final board snapshot: on a natural finish the last move never triggers a
+// game_state event, so the board is the only way clients learn the final letter.
+func TestPublishGameOver_IncludesBoard(t *testing.T) {
+	boardCh := make(chan [5][5]string, 1)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Data struct {
+				Type  string       `json:"type"`
+				Board [5][5]string `json:"board"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode publish request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if payload.Data.Type == "game_over" {
+			boardCh <- payload.Data.Board
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	cf := centrifugo.NewClient(ts.URL, "test-key")
+
+	p1 := &game.Player{ID: "p1", Score: 10, Exp: 100, Type: game.PlayerTypeHuman}
+	p2 := &game.Player{ID: "p2", Score: 5, Exp: 200, Type: game.PlayerTypeHuman}
+
+	coord := New("game-1", []*game.Player{p1, p2}, cf)
+	coord.SetOnGameOver(func(_ storage.GameResult) {})
+
+	g, err := game.NewGameWithWord([]*game.Player{p1, p2}, "масло", coord)
+	require.NoError(t, err)
+	coord.SetGame(g)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go g.Run(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+	g.Kick()
+
+	select {
+	case <-g.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for game to finish")
+	}
+
+	want := g.BoardSnapshot()
+	select {
+	case board := <-boardCh:
+		assert.Equal(t, want, board)
+		// Sanity: the initial word sits in the middle row.
+		assert.Equal(t, [5]string{"м", "а", "с", "л", "о"}, board[2])
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Centrifugo publish")
+	}
+}
+
 // before the Centrifugo Publish call when a game ends via kick. This guarantees
 // the database is the source of truth by the time clients see the game_over event.
 func TestPublishGameOver_PersistsBeforePublish(t *testing.T) {

--- a/internal/server/ogen/oas_client_gen.go
+++ b/internal/server/ogen/oas_client_gen.go
@@ -75,6 +75,13 @@ type Invoker interface {
 	//
 	// GET /player/state/{uid}
 	GetPlayerStateUID(ctx context.Context, params GetPlayerStateUIDParams) (GetPlayerStateUIDRes, error)
+	// GetPlayerStats invokes getPlayerStats operation.
+	//
+	// Returns lifetime aggregated statistics for the currently authenticated player: games played,
+	// wins/losses/draws, win rate, average word length, best word and favorite letter.
+	//
+	// GET /player/stats
+	GetPlayerStats(ctx context.Context) (GetPlayerStatsRes, error)
 	// JoinGame invokes joinGame operation.
 	//
 	// Adds the authenticated player to the specified waiting game. When the second player joins (quorum of
@@ -998,6 +1005,120 @@ func (c *Client) sendGetPlayerStateUID(ctx context.Context, params GetPlayerStat
 
 	stage = "DecodeResponse"
 	result, err := decodeGetPlayerStateUIDResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// GetPlayerStats invokes getPlayerStats operation.
+//
+// Returns lifetime aggregated statistics for the currently authenticated player: games played,
+// wins/losses/draws, win rate, average word length, best word and favorite letter.
+//
+// GET /player/stats
+func (c *Client) GetPlayerStats(ctx context.Context) (GetPlayerStatsRes, error) {
+	res, err := c.sendGetPlayerStats(ctx)
+	return res, err
+}
+
+func (c *Client) sendGetPlayerStats(ctx context.Context) (res GetPlayerStatsRes, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getPlayerStats"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.URLTemplateKey.String("/player/stats"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, GetPlayerStatsOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/player/stats"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			stage = "Security:BearerAuth"
+			switch err := c.securityBearerAuth(ctx, GetPlayerStatsOperation, r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"BearerAuth\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer func() {
+		// Drain the body to EOF before closing, so the underlying
+		// connection can be reused by the Transport regardless of the
+		// response status code. See https://github.com/ogen-go/ogen/issues/1670.
+		_, _ = io.Copy(io.Discard, body)
+		_ = body.Close()
+	}()
+
+	stage = "DecodeResponse"
+	result, err := decodeGetPlayerStatsResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/internal/server/ogen/oas_handlers_gen.go
+++ b/internal/server/ogen/oas_handlers_gen.go
@@ -1221,6 +1221,179 @@ func (s *Server) handleGetPlayerStateUIDRequest(args [1]string, argsEscaped bool
 	}
 }
 
+// handleGetPlayerStatsRequest handles getPlayerStats operation.
+//
+// Returns lifetime aggregated statistics for the currently authenticated player: games played,
+// wins/losses/draws, win rate, average word length, best word and favorite letter.
+//
+// GET /player/stats
+func (s *Server) handleGetPlayerStatsRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getPlayerStats"),
+		semconv.HTTPRequestMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/player/stats"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), GetPlayerStatsOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(attrs...)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: GetPlayerStatsOperation,
+			ID:   "getPlayerStats",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securityBearerAuth(ctx, GetPlayerStatsOperation, r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "BearerAuth",
+					Err:              err,
+				}
+				defer recordError("Security:BearerAuth", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+
+	var rawBody []byte
+
+	var response GetPlayerStatsRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    GetPlayerStatsOperation,
+			OperationSummary: "Get player statistics",
+			OperationID:      "getPlayerStats",
+			Body:             nil,
+			RawBody:          rawBody,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = struct{}
+			Response = GetPlayerStatsRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.GetPlayerStats(ctx)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.GetPlayerStats(ctx)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeGetPlayerStatsResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleJoinGameRequest handles joinGame operation.
 //
 // Adds the authenticated player to the specified waiting game. When the second player joins (quorum of

--- a/internal/server/ogen/oas_interfaces_gen.go
+++ b/internal/server/ogen/oas_interfaces_gen.go
@@ -29,6 +29,10 @@ type GetPlayerStateUIDRes interface {
 	getPlayerStateUIDRes()
 }
 
+type GetPlayerStatsRes interface {
+	getPlayerStatsRes()
+}
+
 type JoinGameRes interface {
 	joinGameRes()
 }

--- a/internal/server/ogen/oas_json_gen.go
+++ b/internal/server/ogen/oas_json_gen.go
@@ -1692,6 +1692,82 @@ func (s *GetPlayerStateUIDUnauthorized) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes GetPlayerStatsInternalServerError as json.
+func (s *GetPlayerStatsInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes GetPlayerStatsInternalServerError from json.
+func (s *GetPlayerStatsInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode GetPlayerStatsInternalServerError to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = GetPlayerStatsInternalServerError(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *GetPlayerStatsInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *GetPlayerStatsInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes GetPlayerStatsUnauthorized as json.
+func (s *GetPlayerStatsUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes GetPlayerStatsUnauthorized from json.
+func (s *GetPlayerStatsUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode GetPlayerStatsUnauthorized to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = GetPlayerStatsUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *GetPlayerStatsUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *GetPlayerStatsUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes JoinGameConflict as json.
 func (s *JoinGameConflict) Encode(e *jx.Encoder) {
 	unwrapped := (*ErrorResponse)(s)
@@ -3300,6 +3376,41 @@ func (s *OptBool) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes float64 as json.
+func (o OptFloat64) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Float64(float64(o.Value))
+}
+
+// Decode decodes float64 from json.
+func (o *OptFloat64) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptFloat64 to nil")
+	}
+	o.Set = true
+	v, err := d.Float64()
+	if err != nil {
+		return err
+	}
+	o.Value = float64(v)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptFloat64) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptFloat64) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes GameStatus as json.
 func (o OptGameStatus) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -4182,6 +4293,188 @@ func (s *PlayerState) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *PlayerState) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *PlayerStatsResponse) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *PlayerStatsResponse) encodeFields(e *jx.Encoder) {
+	{
+		if s.GamesPlayed.Set {
+			e.FieldStart("games_played")
+			s.GamesPlayed.Encode(e)
+		}
+	}
+	{
+		if s.Wins.Set {
+			e.FieldStart("wins")
+			s.Wins.Encode(e)
+		}
+	}
+	{
+		if s.Losses.Set {
+			e.FieldStart("losses")
+			s.Losses.Encode(e)
+		}
+	}
+	{
+		if s.Draws.Set {
+			e.FieldStart("draws")
+			s.Draws.Encode(e)
+		}
+	}
+	{
+		if s.WinRate.Set {
+			e.FieldStart("win_rate")
+			s.WinRate.Encode(e)
+		}
+	}
+	{
+		if s.AvgWordLength.Set {
+			e.FieldStart("avg_word_length")
+			s.AvgWordLength.Encode(e)
+		}
+	}
+	{
+		if s.BestWord.Set {
+			e.FieldStart("best_word")
+			s.BestWord.Encode(e)
+		}
+	}
+	{
+		if s.FavoriteLetter.Set {
+			e.FieldStart("favorite_letter")
+			s.FavoriteLetter.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfPlayerStatsResponse = [8]string{
+	0: "games_played",
+	1: "wins",
+	2: "losses",
+	3: "draws",
+	4: "win_rate",
+	5: "avg_word_length",
+	6: "best_word",
+	7: "favorite_letter",
+}
+
+// Decode decodes PlayerStatsResponse from json.
+func (s *PlayerStatsResponse) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode PlayerStatsResponse to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "games_played":
+			if err := func() error {
+				s.GamesPlayed.Reset()
+				if err := s.GamesPlayed.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"games_played\"")
+			}
+		case "wins":
+			if err := func() error {
+				s.Wins.Reset()
+				if err := s.Wins.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"wins\"")
+			}
+		case "losses":
+			if err := func() error {
+				s.Losses.Reset()
+				if err := s.Losses.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"losses\"")
+			}
+		case "draws":
+			if err := func() error {
+				s.Draws.Reset()
+				if err := s.Draws.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"draws\"")
+			}
+		case "win_rate":
+			if err := func() error {
+				s.WinRate.Reset()
+				if err := s.WinRate.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"win_rate\"")
+			}
+		case "avg_word_length":
+			if err := func() error {
+				s.AvgWordLength.Reset()
+				if err := s.AvgWordLength.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"avg_word_length\"")
+			}
+		case "best_word":
+			if err := func() error {
+				s.BestWord.Reset()
+				if err := s.BestWord.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"best_word\"")
+			}
+		case "favorite_letter":
+			if err := func() error {
+				s.FavoriteLetter.Reset()
+				if err := s.FavoriteLetter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"favorite_letter\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode PlayerStatsResponse")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *PlayerStatsResponse) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *PlayerStatsResponse) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/server/ogen/oas_operations_gen.go
+++ b/internal/server/ogen/oas_operations_gen.go
@@ -13,6 +13,7 @@ const (
 	GetLeaderboardOperation        OperationName = "GetLeaderboard"
 	GetPlayerAchievementsOperation OperationName = "GetPlayerAchievements"
 	GetPlayerStateUIDOperation     OperationName = "GetPlayerStateUID"
+	GetPlayerStatsOperation        OperationName = "GetPlayerStats"
 	JoinGameOperation              OperationName = "JoinGame"
 	ListGamesOperation             OperationName = "ListGames"
 	LogoutOperation                OperationName = "Logout"

--- a/internal/server/ogen/oas_response_decoders_gen.go
+++ b/internal/server/ogen/oas_response_decoders_gen.go
@@ -875,6 +875,126 @@ func decodeGetPlayerStateUIDResponse(resp *http.Response) (res GetPlayerStateUID
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
+func decodeGetPlayerStatsResponse(resp *http.Response) (res GetPlayerStatsRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response PlayerStatsResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response GetPlayerStatsUnauthorized
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response GetPlayerStatsInternalServerError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
 func decodeJoinGameResponse(resp *http.Response) (res JoinGameRes, _ error) {
 	switch resp.StatusCode {
 	case 200:

--- a/internal/server/ogen/oas_response_encoders_gen.go
+++ b/internal/server/ogen/oas_response_encoders_gen.go
@@ -334,6 +334,50 @@ func encodeGetPlayerStateUIDResponse(response GetPlayerStateUIDRes, w http.Respo
 	}
 }
 
+func encodeGetPlayerStatsResponse(response GetPlayerStatsRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *PlayerStatsResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *GetPlayerStatsUnauthorized:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(401)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *GetPlayerStatsInternalServerError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodeJoinGameResponse(response JoinGameRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *JoinGameResponse:

--- a/internal/server/ogen/oas_router_gen.go
+++ b/internal/server/ogen/oas_router_gen.go
@@ -14,10 +14,10 @@ var (
 	rn5AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
-	rn15AllowedHeaders = map[string]string{
+	rn17AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type",
 	}
-	rn20AllowedHeaders = map[string]string{
+	rn22AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
 	rn6AllowedHeaders = map[string]string{
@@ -30,19 +30,19 @@ var (
 	rn3AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn14AllowedHeaders = map[string]string{
-		"POST": "Authorization",
-	}
 	rn16AllowedHeaders = map[string]string{
-		"POST": "Authorization,Content-Type",
+		"POST": "Authorization",
 	}
 	rn18AllowedHeaders = map[string]string{
+		"POST": "Authorization,Content-Type",
+	}
+	rn20AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn21AllowedHeaders = map[string]string{
+	rn23AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn24AllowedHeaders = map[string]string{
+	rn26AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
 	rn9AllowedHeaders = map[string]string{
@@ -51,10 +51,13 @@ var (
 	rn12AllowedHeaders = map[string]string{
 		"GET": "Authorization",
 	}
-	rn17AllowedHeaders = map[string]string{
+	rn14AllowedHeaders = map[string]string{
+		"GET": "Authorization",
+	}
+	rn19AllowedHeaders = map[string]string{
 		"POST": "Authorization,X-Request-Id",
 	}
-	rn23AllowedHeaders = map[string]string{
+	rn25AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
 )
@@ -162,7 +165,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn15AllowedHeaders,
+									allowedHeaders: rn17AllowedHeaders,
 									acceptPost:     "application/json",
 									acceptPatch:    "",
 								})
@@ -187,7 +190,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn20AllowedHeaders,
+									allowedHeaders: rn22AllowedHeaders,
 									acceptPost:     "application/json",
 									acceptPatch:    "",
 								})
@@ -335,7 +338,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn14AllowedHeaders,
+										allowedHeaders: rn16AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -362,7 +365,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn16AllowedHeaders,
+										allowedHeaders: rn18AllowedHeaders,
 										acceptPost:     "application/json",
 										acceptPatch:    "",
 									})
@@ -389,7 +392,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn18AllowedHeaders,
+										allowedHeaders: rn20AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -416,7 +419,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn21AllowedHeaders,
+										allowedHeaders: rn23AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -443,7 +446,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn24AllowedHeaders,
+										allowedHeaders: rn26AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -520,40 +523,79 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 
-				case 's': // Prefix: "state/"
+				case 's': // Prefix: "stat"
 
-					if l := len("state/"); len(elem) >= l && elem[0:l] == "state/" {
+					if l := len("stat"); len(elem) >= l && elem[0:l] == "stat" {
 						elem = elem[l:]
 					} else {
 						break
 					}
 
-					// Param: "uid"
-					// Leaf parameter, slashes are prohibited
-					idx := strings.IndexByte(elem, '/')
-					if idx >= 0 {
+					if len(elem) == 0 {
 						break
 					}
-					args[0] = elem
-					elem = ""
+					switch elem[0] {
+					case 'e': // Prefix: "e/"
 
-					if len(elem) == 0 {
-						// Leaf node.
-						switch r.Method {
-						case "GET":
-							s.handleGetPlayerStateUIDRequest([1]string{
-								args[0],
-							}, elemIsEscaped, w, r)
-						default:
-							s.notAllowed(w, r, notAllowedParams{
-								allowedMethods: "GET",
-								allowedHeaders: rn12AllowedHeaders,
-								acceptPost:     "",
-								acceptPatch:    "",
-							})
+						if l := len("e/"); len(elem) >= l && elem[0:l] == "e/" {
+							elem = elem[l:]
+						} else {
+							break
 						}
 
-						return
+						// Param: "uid"
+						// Leaf parameter, slashes are prohibited
+						idx := strings.IndexByte(elem, '/')
+						if idx >= 0 {
+							break
+						}
+						args[0] = elem
+						elem = ""
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch r.Method {
+							case "GET":
+								s.handleGetPlayerStateUIDRequest([1]string{
+									args[0],
+								}, elemIsEscaped, w, r)
+							default:
+								s.notAllowed(w, r, notAllowedParams{
+									allowedMethods: "GET",
+									allowedHeaders: rn12AllowedHeaders,
+									acceptPost:     "",
+									acceptPatch:    "",
+								})
+							}
+
+							return
+						}
+
+					case 's': // Prefix: "s"
+
+						if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch r.Method {
+							case "GET":
+								s.handleGetPlayerStatsRequest([0]string{}, elemIsEscaped, w, r)
+							default:
+								s.notAllowed(w, r, notAllowedParams{
+									allowedMethods: "GET",
+									allowedHeaders: rn14AllowedHeaders,
+									acceptPost:     "",
+									acceptPatch:    "",
+								})
+							}
+
+							return
+						}
+
 					}
 
 				}
@@ -586,7 +628,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn17AllowedHeaders,
+								allowedHeaders: rn19AllowedHeaders,
 								acceptPost:     "",
 								acceptPatch:    "",
 							})
@@ -611,7 +653,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn23AllowedHeaders,
+								allowedHeaders: rn25AllowedHeaders,
 								acceptPost:     "application/json",
 								acceptPatch:    "",
 							})
@@ -1127,38 +1169,77 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 
-				case 's': // Prefix: "state/"
+				case 's': // Prefix: "stat"
 
-					if l := len("state/"); len(elem) >= l && elem[0:l] == "state/" {
+					if l := len("stat"); len(elem) >= l && elem[0:l] == "stat" {
 						elem = elem[l:]
 					} else {
 						break
 					}
 
-					// Param: "uid"
-					// Leaf parameter, slashes are prohibited
-					idx := strings.IndexByte(elem, '/')
-					if idx >= 0 {
+					if len(elem) == 0 {
 						break
 					}
-					args[0] = elem
-					elem = ""
+					switch elem[0] {
+					case 'e': // Prefix: "e/"
 
-					if len(elem) == 0 {
-						// Leaf node.
-						switch method {
-						case "GET":
-							r.name = GetPlayerStateUIDOperation
-							r.summary = "Get user state"
-							r.operationID = "getPlayerStateUID"
-							r.operationGroup = ""
-							r.pathPattern = "/player/state/{uid}"
-							r.args = args
-							r.count = 1
-							return r, true
-						default:
-							return
+						if l := len("e/"); len(elem) >= l && elem[0:l] == "e/" {
+							elem = elem[l:]
+						} else {
+							break
 						}
+
+						// Param: "uid"
+						// Leaf parameter, slashes are prohibited
+						idx := strings.IndexByte(elem, '/')
+						if idx >= 0 {
+							break
+						}
+						args[0] = elem
+						elem = ""
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch method {
+							case "GET":
+								r.name = GetPlayerStateUIDOperation
+								r.summary = "Get user state"
+								r.operationID = "getPlayerStateUID"
+								r.operationGroup = ""
+								r.pathPattern = "/player/state/{uid}"
+								r.args = args
+								r.count = 1
+								return r, true
+							default:
+								return
+							}
+						}
+
+					case 's': // Prefix: "s"
+
+						if l := len("s"); len(elem) >= l && elem[0:l] == "s" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch method {
+							case "GET":
+								r.name = GetPlayerStatsOperation
+								r.summary = "Get player statistics"
+								r.operationID = "getPlayerStats"
+								r.operationGroup = ""
+								r.pathPattern = "/player/stats"
+								r.args = args
+								r.count = 0
+								return r, true
+							default:
+								return
+							}
+						}
+
 					}
 
 				}

--- a/internal/server/ogen/oas_schemas_gen.go
+++ b/internal/server/ogen/oas_schemas_gen.go
@@ -737,6 +737,14 @@ type GetPlayerStateUIDUnauthorized ErrorResponse
 
 func (*GetPlayerStateUIDUnauthorized) getPlayerStateUIDRes() {}
 
+type GetPlayerStatsInternalServerError ErrorResponse
+
+func (*GetPlayerStatsInternalServerError) getPlayerStatsRes() {}
+
+type GetPlayerStatsUnauthorized ErrorResponse
+
+func (*GetPlayerStatsUnauthorized) getPlayerStatsRes() {}
+
 type JoinGameConflict ErrorResponse
 
 func (*JoinGameConflict) joinGameRes() {}
@@ -1371,6 +1379,52 @@ func (o OptBool) Get() (v bool, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptBool) Or(d bool) bool {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptFloat64 returns new OptFloat64 with value set to v.
+func NewOptFloat64(v float64) OptFloat64 {
+	return OptFloat64{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptFloat64 is optional float64.
+type OptFloat64 struct {
+	Value float64
+	Set   bool
+}
+
+// IsSet returns true if OptFloat64 was set.
+func (o OptFloat64) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptFloat64) Reset() {
+	var v float64
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptFloat64) SetTo(v float64) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptFloat64) Get() (v float64, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptFloat64) Or(d float64) float64 {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -2170,6 +2224,108 @@ func (s *PlayerState) SetGameID(val OptUUID) {
 }
 
 func (*PlayerState) getPlayerStateUIDRes() {}
+
+// Ref: #/components/schemas/PlayerStatsResponse
+type PlayerStatsResponse struct {
+	// Total number of finished games.
+	GamesPlayed OptInt64 `json:"games_played"`
+	// Number of games won.
+	Wins OptInt64 `json:"wins"`
+	// Number of games lost.
+	Losses OptInt64 `json:"losses"`
+	// Number of games ended in a draw.
+	Draws OptInt64 `json:"draws"`
+	// Win rate as a fraction (0..1).
+	WinRate OptFloat64 `json:"win_rate"`
+	// Average length of submitted words in letters.
+	AvgWordLength OptFloat64 `json:"avg_word_length"`
+	// Longest word ever submitted (empty if no games with recorded words).
+	BestWord OptString `json:"best_word"`
+	// Most frequently used letter across all submitted words (empty if none).
+	FavoriteLetter OptString `json:"favorite_letter"`
+}
+
+// GetGamesPlayed returns the value of GamesPlayed.
+func (s *PlayerStatsResponse) GetGamesPlayed() OptInt64 {
+	return s.GamesPlayed
+}
+
+// GetWins returns the value of Wins.
+func (s *PlayerStatsResponse) GetWins() OptInt64 {
+	return s.Wins
+}
+
+// GetLosses returns the value of Losses.
+func (s *PlayerStatsResponse) GetLosses() OptInt64 {
+	return s.Losses
+}
+
+// GetDraws returns the value of Draws.
+func (s *PlayerStatsResponse) GetDraws() OptInt64 {
+	return s.Draws
+}
+
+// GetWinRate returns the value of WinRate.
+func (s *PlayerStatsResponse) GetWinRate() OptFloat64 {
+	return s.WinRate
+}
+
+// GetAvgWordLength returns the value of AvgWordLength.
+func (s *PlayerStatsResponse) GetAvgWordLength() OptFloat64 {
+	return s.AvgWordLength
+}
+
+// GetBestWord returns the value of BestWord.
+func (s *PlayerStatsResponse) GetBestWord() OptString {
+	return s.BestWord
+}
+
+// GetFavoriteLetter returns the value of FavoriteLetter.
+func (s *PlayerStatsResponse) GetFavoriteLetter() OptString {
+	return s.FavoriteLetter
+}
+
+// SetGamesPlayed sets the value of GamesPlayed.
+func (s *PlayerStatsResponse) SetGamesPlayed(val OptInt64) {
+	s.GamesPlayed = val
+}
+
+// SetWins sets the value of Wins.
+func (s *PlayerStatsResponse) SetWins(val OptInt64) {
+	s.Wins = val
+}
+
+// SetLosses sets the value of Losses.
+func (s *PlayerStatsResponse) SetLosses(val OptInt64) {
+	s.Losses = val
+}
+
+// SetDraws sets the value of Draws.
+func (s *PlayerStatsResponse) SetDraws(val OptInt64) {
+	s.Draws = val
+}
+
+// SetWinRate sets the value of WinRate.
+func (s *PlayerStatsResponse) SetWinRate(val OptFloat64) {
+	s.WinRate = val
+}
+
+// SetAvgWordLength sets the value of AvgWordLength.
+func (s *PlayerStatsResponse) SetAvgWordLength(val OptFloat64) {
+	s.AvgWordLength = val
+}
+
+// SetBestWord sets the value of BestWord.
+func (s *PlayerStatsResponse) SetBestWord(val OptString) {
+	s.BestWord = val
+}
+
+// SetFavoriteLetter sets the value of FavoriteLetter.
+func (s *PlayerStatsResponse) SetFavoriteLetter(val OptString) {
+	s.FavoriteLetter = val
+}
+
+func (*PlayerStatsResponse) getPlayerStatsRes() {}
 
 type ProposeEndGameConflict ErrorResponse
 

--- a/internal/server/ogen/oas_security_gen.go
+++ b/internal/server/ogen/oas_security_gen.go
@@ -39,6 +39,7 @@ var operationRolesBearerAuth = map[string][]string{
 	CreateGameWithBotOperation:     []string{},
 	GetPlayerAchievementsOperation: []string{},
 	GetPlayerStateUIDOperation:     []string{},
+	GetPlayerStatsOperation:        []string{},
 	JoinGameOperation:              []string{},
 	ListGamesOperation:             []string{},
 	LogoutOperation:                []string{},

--- a/internal/server/ogen/oas_server_gen.go
+++ b/internal/server/ogen/oas_server_gen.go
@@ -54,6 +54,13 @@ type Handler interface {
 	//
 	// GET /player/state/{uid}
 	GetPlayerStateUID(ctx context.Context, params GetPlayerStateUIDParams) (GetPlayerStateUIDRes, error)
+	// GetPlayerStats implements getPlayerStats operation.
+	//
+	// Returns lifetime aggregated statistics for the currently authenticated player: games played,
+	// wins/losses/draws, win rate, average word length, best word and favorite letter.
+	//
+	// GET /player/stats
+	GetPlayerStats(ctx context.Context) (GetPlayerStatsRes, error)
 	// JoinGame implements joinGame operation.
 	//
 	// Adds the authenticated player to the specified waiting game. When the second player joins (quorum of

--- a/internal/server/ogen/oas_unimplemented_gen.go
+++ b/internal/server/ogen/oas_unimplemented_gen.go
@@ -80,6 +80,16 @@ func (UnimplementedHandler) GetPlayerStateUID(ctx context.Context, params GetPla
 	return r, ht.ErrNotImplemented
 }
 
+// GetPlayerStats implements getPlayerStats operation.
+//
+// Returns lifetime aggregated statistics for the currently authenticated player: games played,
+// wins/losses/draws, win rate, average word length, best word and favorite letter.
+//
+// GET /player/stats
+func (UnimplementedHandler) GetPlayerStats(ctx context.Context) (r GetPlayerStatsRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // JoinGame implements joinGame operation.
 //
 // Adds the authenticated player to the specified waiting game. When the second player joins (quorum of

--- a/internal/server/ogen/oas_validators_gen.go
+++ b/internal/server/ogen/oas_validators_gen.go
@@ -753,6 +753,54 @@ func (s *PlayerAchievementsResponse) Validate() error {
 	return nil
 }
 
+func (s *PlayerStatsResponse) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.WinRate.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "win_rate",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.AvgWordLength.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "avg_word_length",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *SignupRequest) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer

--- a/internal/server/restapi/handlers/player_stats.go
+++ b/internal/server/restapi/handlers/player_stats.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/rustwizard/balda/internal/auth"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+)
+
+// GetPlayerStats implements baldaapi.Handler.
+func (h *Handlers) GetPlayerStats(ctx context.Context) (baldaapi.GetPlayerStatsRes, error) {
+	claims, ok := auth.FromContext(ctx)
+	if !ok {
+		return &baldaapi.GetPlayerStatsUnauthorized{
+			Status:  baldaapi.NewOptInt(http.StatusUnauthorized),
+			Message: baldaapi.NewOptString("unauthorized"),
+			Type:    baldaapi.NewOptString("Unauthorized"),
+		}, nil
+	}
+
+	stats, err := h.svc.GetPlayerStats(ctx, claims.PlayerID)
+	if err != nil {
+		slog.Error("get player stats", slog.Any("error", err))
+		return &baldaapi.GetPlayerStatsInternalServerError{
+			Status:  baldaapi.NewOptInt(http.StatusInternalServerError),
+			Message: baldaapi.NewOptString("failed to get player stats"),
+			Type:    baldaapi.NewOptString("InternalServerError"),
+		}, nil
+	}
+
+	return &baldaapi.PlayerStatsResponse{
+		GamesPlayed:    baldaapi.NewOptInt64(stats.GamesPlayed),
+		Wins:           baldaapi.NewOptInt64(stats.Wins),
+		Losses:         baldaapi.NewOptInt64(stats.Losses),
+		Draws:          baldaapi.NewOptInt64(stats.Draws),
+		WinRate:        baldaapi.NewOptFloat64(stats.WinRate),
+		AvgWordLength:  baldaapi.NewOptFloat64(stats.AvgWordLength),
+		BestWord:       baldaapi.NewOptString(stats.BestWord),
+		FavoriteLetter: baldaapi.NewOptString(stats.FavoriteLetter),
+	}, nil
+}

--- a/internal/service/balda_service.go
+++ b/internal/service/balda_service.go
@@ -89,6 +89,11 @@ func (s *Balda) GetPlayerAchievements(ctx context.Context, playerID uuid.UUID) (
 	return s.ach.List(ps.Flags), nil
 }
 
+// GetPlayerStats returns lifetime aggregated statistics for the player.
+func (s *Balda) GetPlayerStats(ctx context.Context, playerID uuid.UUID) (storage.PlayerStats, error) {
+	return s.s.GetPlayerStats(ctx, playerID)
+}
+
 // GetUserForToken returns the player UUID and role needed to mint an access token.
 func (s *Balda) GetUserForToken(ctx context.Context, uid int64) (storage.UserForToken, error) {
 	return s.s.GetUserForToken(ctx, uid)

--- a/internal/storage/game_result.go
+++ b/internal/storage/game_result.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"time"
@@ -27,6 +28,7 @@ type PlayerResult struct {
 	WordsCount     int
 	ExpGained      int
 	BestWordLength int
+	Words          []string
 }
 
 type GameResult struct {
@@ -134,10 +136,18 @@ func (b *Balda) SaveGameResultWithAchievements(ctx context.Context, r GameResult
 	var unlocks []PlayerAchievementUnlock
 
 	for _, p := range r.Players {
+		wordsJSON, err := json.Marshal(p.Words)
+		if err != nil {
+			return nil, fmt.Errorf("save game result: marshal words for %s: %w", p.PlayerID, err)
+		}
+		if p.Words == nil {
+			wordsJSON = []byte("[]")
+		}
+
 		_, err = tx.Exec(ctx,
-			`INSERT INTO game_result_players (game_result_id, player_id, score, words_count, exp_gained, best_word_length)
-			 VALUES ($1, $2, $3, $4, $5, $6)`,
-			resultID, p.PlayerID, p.Score, p.WordsCount, p.ExpGained, p.BestWordLength,
+			`INSERT INTO game_result_players (game_result_id, player_id, score, words_count, exp_gained, best_word_length, words)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			resultID, p.PlayerID, p.Score, p.WordsCount, p.ExpGained, p.BestWordLength, wordsJSON,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("save game result: insert game_result_players for %s: %w", p.PlayerID, err)

--- a/internal/storage/player_stats.go
+++ b/internal/storage/player_stats.go
@@ -1,0 +1,129 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+)
+
+// PlayerStats holds aggregated lifetime statistics for a player.
+type PlayerStats struct {
+	GamesPlayed    int64
+	Wins           int64
+	Losses         int64
+	Draws          int64
+	WinRate        float64 // 0..1
+	AvgWordLength  float64
+	BestWord       string
+	FavoriteLetter string
+}
+
+// GetPlayerStats aggregates lifetime statistics for the given player from
+// game_results/game_result_players. Average word length is derived from
+// score (= total letters of all words) over words_count, so it also covers
+// games saved before words were persisted. Best word and favorite letter
+// only consider games where words were recorded.
+func (b *Balda) GetPlayerStats(ctx context.Context, playerID uuid.UUID) (PlayerStats, error) {
+	ctx, cancel := context.WithTimeout(ctx, b.t)
+	defer cancel()
+
+	rows, err := b.db.Query(ctx,
+		`SELECT p.score, p.words_count, p.words, r.winner_id
+		 FROM game_result_players p
+		 JOIN game_results r ON r.id = p.game_result_id
+		 WHERE p.player_id = $1`,
+		playerID,
+	)
+	if err != nil {
+		return PlayerStats{}, fmt.Errorf("get player stats: %w", err)
+	}
+	defer rows.Close()
+
+	var stats PlayerStats
+	var totalScore, totalWords int64
+	var allWords []string
+
+	for rows.Next() {
+		var score, wordsCount int64
+		var wordsJSON []byte
+		var winnerID *uuid.UUID
+		if err := rows.Scan(&score, &wordsCount, &wordsJSON, &winnerID); err != nil {
+			return PlayerStats{}, fmt.Errorf("get player stats scan: %w", err)
+		}
+
+		stats.GamesPlayed++
+		totalScore += score
+		totalWords += wordsCount
+
+		switch {
+		case winnerID == nil:
+			stats.Draws++
+		case *winnerID == playerID:
+			stats.Wins++
+		default:
+			stats.Losses++
+		}
+
+		if len(wordsJSON) > 0 {
+			var words []string
+			if err := json.Unmarshal(wordsJSON, &words); err != nil {
+				return PlayerStats{}, fmt.Errorf("get player stats: decode words: %w", err)
+			}
+			allWords = append(allWords, words...)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return PlayerStats{}, fmt.Errorf("get player stats rows: %w", err)
+	}
+
+	if stats.GamesPlayed > 0 {
+		stats.WinRate = float64(stats.Wins) / float64(stats.GamesPlayed)
+	}
+	if totalWords > 0 {
+		stats.AvgWordLength = float64(totalScore) / float64(totalWords)
+	}
+	stats.BestWord = bestWord(allWords)
+	stats.FavoriteLetter = favoriteLetter(allWords)
+
+	return stats, nil
+}
+
+// bestWord returns the longest word by rune count; ties keep the first one.
+func bestWord(words []string) string {
+	best := ""
+	bestLen := 0
+	for _, w := range words {
+		if l := utf8.RuneCountInString(w); l > bestLen {
+			best, bestLen = w, l
+		}
+	}
+	return best
+}
+
+// favoriteLetter returns the most frequent Cyrillic letter across all words.
+// Letters are lowercased and ё is folded into е, matching the game rules.
+// Ties keep the letter that reached its maximum first.
+func favoriteLetter(words []string) string {
+	counts := make(map[rune]int)
+	best := rune(0)
+	bestCount := 0
+	for _, w := range words {
+		for _, r := range strings.ToLower(w) {
+			if r == 'ё' {
+				r = 'е'
+			}
+			counts[r]++
+			if counts[r] > bestCount {
+				best, bestCount = r, counts[r]
+			}
+		}
+	}
+	if best == 0 {
+		return ""
+	}
+	return string(best)
+}

--- a/internal/storage/player_stats_test.go
+++ b/internal/storage/player_stats_test.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBestWord(t *testing.T) {
+	cases := []struct {
+		name  string
+		words []string
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"single", []string{"кот"}, "кот"},
+		{"longest wins", []string{"дом", "автостоп", "мир"}, "автостоп"},
+		{"tie keeps first", []string{"кот", "дом"}, "кот"},
+		{"cyrillic rune length", []string{"abcd", "ёлка"}, "abcd"}, // both 4 runes, first wins
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, bestWord(tc.words))
+		})
+	}
+}
+
+func TestFavoriteLetter(t *testing.T) {
+	cases := []struct {
+		name  string
+		words []string
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"single word", []string{"абажур"}, "а"},
+		{"most frequent", []string{"кот", "дом", "автостоп"}, "о"},
+		{"yo folds into ye", []string{"ёлка", "ель"}, "е"},
+		{"case insensitive", []string{"АБА", "абажур"}, "а"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, favoriteLetter(tc.words))
+		})
+	}
+}

--- a/migrations/010_game_result_words.up.sql
+++ b/migrations/010_game_result_words.up.sql
@@ -1,0 +1,6 @@
+alter table game_result_players
+    add column if not exists words jsonb;
+
+---- create above / drop below ----
+
+alter table game_result_players drop column if exists words;

--- a/tests/player_stats_test.go
+++ b/tests/player_stats_test.go
@@ -1,0 +1,120 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rustwizard/balda/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPlayerStats(t *testing.T) {
+	ctx := context.Background()
+	s, cleanup := initStorage(ctx, t)
+	defer cleanup()
+
+	p1 := seedPlayer(ctx, t, s, "stats.hero@example.org")
+	p2 := seedPlayer(ctx, t, s, "stats.rival@example.org")
+
+	// Game 1: p1 wins, submits "кот" and "дом".
+	require.NoError(t, s.SaveGameResult(ctx, storage.GameResult{
+		GameID:       "11111111-1111-1111-1111-111111111111",
+		WinnerID:     p1.String(),
+		FinishReason: storage.FinishReasonGameFinished,
+		FinishedAt:   time.Now().UTC(),
+		Players: []storage.PlayerResult{
+			{PlayerID: p1.String(), Score: 6, WordsCount: 2, ExpGained: 16, Words: []string{"кот", "дом"}},
+			{PlayerID: p2.String(), Score: 3, WordsCount: 1, ExpGained: 3, Words: []string{"мир"}},
+		},
+	}))
+
+	// Game 2: draw, p1 submits "автостоп".
+	require.NoError(t, s.SaveGameResult(ctx, storage.GameResult{
+		GameID:       "22222222-2222-2222-2222-222222222222",
+		WinnerID:     "",
+		FinishReason: storage.FinishReasonAcceptEnd,
+		FinishedAt:   time.Now().UTC(),
+		Players: []storage.PlayerResult{
+			{PlayerID: p1.String(), Score: 8, WordsCount: 1, ExpGained: 13, Words: []string{"автостоп"}},
+			{PlayerID: p2.String(), Score: 8, WordsCount: 1, ExpGained: 13, Words: []string{"провода"}},
+		},
+	}))
+
+	stats, err := s.GetPlayerStats(ctx, p1)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), stats.GamesPlayed)
+	assert.Equal(t, int64(1), stats.Wins)
+	assert.Equal(t, int64(0), stats.Losses)
+	assert.Equal(t, int64(1), stats.Draws)
+	assert.InDelta(t, 0.5, stats.WinRate, 1e-9)
+	// total score 6+8=14 over 3 words.
+	assert.InDelta(t, 14.0/3.0, stats.AvgWordLength, 1e-9)
+	assert.Equal(t, "автостоп", stats.BestWord)
+	assert.Equal(t, "о", stats.FavoriteLetter)
+
+	// The rival's perspective: one loss, one draw.
+	rival, err := s.GetPlayerStats(ctx, p2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), rival.GamesPlayed)
+	assert.Equal(t, int64(0), rival.Wins)
+	assert.Equal(t, int64(1), rival.Losses)
+	assert.Equal(t, int64(1), rival.Draws)
+	assert.Equal(t, "провода", rival.BestWord)
+}
+
+func TestGetPlayerStats_NoGames(t *testing.T) {
+	ctx := context.Background()
+	s, cleanup := initStorage(ctx, t)
+	defer cleanup()
+
+	p := seedPlayer(ctx, t, s, "stats.newbie@example.org")
+
+	stats, err := s.GetPlayerStats(ctx, p)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats.GamesPlayed)
+	assert.Equal(t, 0.0, stats.WinRate)
+	assert.Equal(t, 0.0, stats.AvgWordLength)
+	assert.Equal(t, "", stats.BestWord)
+	assert.Equal(t, "", stats.FavoriteLetter)
+}
+
+func TestSaveGameResult_PersistsWords(t *testing.T) {
+	ctx := context.Background()
+	s, cleanup := initStorage(ctx, t)
+	defer cleanup()
+
+	p1 := seedPlayer(ctx, t, s, "stats.words1@example.org")
+	p2 := seedPlayer(ctx, t, s, "stats.words2@example.org")
+
+	require.NoError(t, s.SaveGameResult(ctx, storage.GameResult{
+		GameID:       "33333333-3333-3333-3333-333333333333",
+		WinnerID:     p1.String(),
+		FinishReason: storage.FinishReasonGameFinished,
+		FinishedAt:   time.Now().UTC(),
+		Players: []storage.PlayerResult{
+			{PlayerID: p1.String(), Score: 6, WordsCount: 2, ExpGained: 16, Words: []string{"кот", "дом"}},
+			{PlayerID: p2.String(), Score: 0, WordsCount: 0, ExpGained: 0},
+		},
+	}))
+
+	var words string
+	require.NoError(t, s.Pool().QueryRow(ctx,
+		`SELECT words::text FROM game_result_players p
+		 JOIN game_results r ON r.id = p.game_result_id
+		 WHERE r.game_id = $1 AND p.player_id = $2`,
+		"33333333-3333-3333-3333-333333333333", p1,
+	).Scan(&words))
+	assert.JSONEq(t, `["кот","дом"]`, words)
+
+	// A player without words gets an empty array, not NULL.
+	require.NoError(t, s.Pool().QueryRow(ctx,
+		`SELECT words::text FROM game_result_players p
+		 JOIN game_results r ON r.id = p.game_result_id
+		 WHERE r.game_id = $1 AND p.player_id = $2`,
+		"33333333-3333-3333-3333-333333333333", p2,
+	).Scan(&words))
+	assert.JSONEq(t, `[]`, words)
+}


### PR DESCRIPTION
- migration 010: words jsonb column in game_result_players, persisted by SaveGameResult (from game.PlayerState.Words)
- storage.GetPlayerStats: games/wins/losses/draws, win rate, avg word length (SUM(score)/SUM(words_count)), best word, favorite letter
- GET /player/stats (BearerAuth) + regenerated ogen code
- frontend: StatsModal.svelte with metrics, 📊 button in lobby

Implements item 34 from docs/IMPROVEMENTS.md