### PR TITLE
feat: Telegram Mini App auth via initData

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -14,3 +14,7 @@ PG_PASSWORD=
 # client connection tokens.
 CENTRIFUGO_API_KEY=
 CENTRIFUGO_SECRET=
+
+# Telegram bot token from @BotFather (needed for Mini App auth). Optional:
+# without it /auth/telegram answers 503 and email login keeps working.
+TELEGRAM_BOT_TOKEN=

--- a/api/openapi/http-api.yaml
+++ b/api/openapi/http-api.yaml
@@ -67,6 +67,48 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /auth/telegram:
+    post:
+      operationId: authTelegram
+      summary: Authenticate via Telegram Mini App init data
+      description: |
+        Validates the signed init data produced by the Telegram WebView
+        against the bot token, then logs in an existing user or creates a
+        new one linked to their Telegram account.
+      tags:
+        - Auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TelegramAuthRequest"
+      responses:
+        "200":
+          description: Response for auth request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+        "401":
+          description: Invalid or expired init data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Telegram auth is not configured on the server
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /auth/refresh:
     post:
       operationId: refreshToken
@@ -768,6 +810,16 @@ components:
         password:
           description: User's password
           example: some_password
+          type: string
+
+    TelegramAuthRequest:
+      type: object
+      required:
+        - init_data
+      properties:
+        init_data:
+          description: Raw init data string provided by the Telegram WebView (window.Telegram.WebApp.initData)
+          example: query_id=AAHdF6IQAAAAAN0XohDhrOrc&user=%7B%22id%22%3A279058397%7D&auth_date=1662771648&hash=c501b71e775f74ce10e377dea85a7ea24ecd640b223ea86dfe453e0eaed2e2b2
           type: string
 
     AuthResponse:

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -85,6 +85,12 @@ type AuthConfig struct {
 	EmailSignupEnabled bool
 }
 
+type TelegramConfig struct {
+	// BotToken validates Telegram Mini App init data. Empty means Telegram
+	// auth is not configured; the endpoint then answers 503.
+	BotToken string
+}
+
 type Config struct {
 	ServerAddr string
 	ServerPort int
@@ -93,6 +99,7 @@ type Config struct {
 	Presence   presence.Config
 	Auth       AuthConfig
 	Centrifugo CentrifugoConfig
+	Telegram   TelegramConfig
 }
 
 // serverCmd represents the server command
@@ -185,7 +192,7 @@ var serverCmd = &cobra.Command{
 
 		svc := service.New(lby, mm, s, lb, achSvc)
 
-		h := handlers.New(svc, pres, cfg.Auth.JWTSecret, cf, cfg.Centrifugo.TokenHMACSecret, cfg.Auth.EmailSignupEnabled)
+		h := handlers.New(svc, pres, cfg.Auth.JWTSecret, cf, cfg.Centrifugo.TokenHMACSecret, cfg.Auth.EmailSignupEnabled, cfg.Telegram.BotToken)
 
 		srv, err := baldaapi.NewServer(h, h,
 			baldaapi.WithPathPrefix("/balda/api/v1"),
@@ -272,6 +279,7 @@ func (c *Config) Flags(prefix string) *pflag.FlagSet {
 	f.StringVar(&c.Pg.SSL, "pg.ssl", "disable", "postgres ssl")
 	f.StringVar(&c.Auth.JWTSecret, "auth.jwt_secret", "", "HMAC secret for signing JWT access tokens")
 	f.BoolVar(&c.Auth.EmailSignupEnabled, "auth.email_signup_enabled", true, "allow email/password registration (disable in prod)")
+	f.StringVar(&c.Telegram.BotToken, "telegram.bot_token", "", "telegram bot token for Mini App auth (init data validation)")
 	f.StringVar(&c.Centrifugo.APIURL, "centrifugo.api_url", "http://127.0.0.1:8000/api", "centrifugo api url")
 	f.StringVar(&c.Centrifugo.APIKey, "centrifugo.api_key", "", "centrifugo api key")
 	f.StringVar(&c.Centrifugo.TokenHMACSecret, "centrifugo.token_hmac_secret_key", "", "centrifugo token hmac secret")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,6 +52,8 @@ services:
       # Email/password registration is for local testing only; prod users
       # will authenticate via Telegram. Login for existing accounts stays on.
       AUTH_EMAIL_SIGNUP_ENABLED: "false"
+      # Telegram Mini App auth (optional; endpoint answers 503 when empty).
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
       PG_HOST: pg
       PG_USER: balda
       PG_DATABASE: balda

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -84,18 +84,21 @@ docker compose -f docker-compose.prod.yml logs --tail 200 centrifugo
 
 ## Telegram Mini App (следующий шаг после прода)
 
-1. `@BotFather` → `/newbot` — получить токен бота.
-2. `/newapp` (или «Bot Settings → Mini Apps») — указать `https://$DOMAIN`
-   как URL мини-аппа.
-3. Бот без логики уже работает как «лаунчер»: кнопка открывает игру.
-4. Авторизация пока остаётся email/пароль внутри игры. Бесшовный вход через
-   Telegram `initData` — отдельная задача (нужен эндпоинт проверки подписи
-   initData → выдача нашего JWT).
+1. `@BotFather` → `/newbot` — получить токен бота (вида `123456:ABC-...`).
+2. Вписать токен в `.env` (`TELEGRAM_BOT_TOKEN`) и перезапустить:
+   `docker compose -f docker-compose.prod.yml up -d`.
+   Без токена `/auth/telegram` отвечает 503, остальное работает как раньше.
+3. `/newapp` (или «Bot Settings → Mini Apps») — указать `https://$DOMAIN`
+   как URL мини-аппа, выбрать короткое имя ссылки (вида `t.me/<bot>/<app>`).
+4. Пользователь открывает Mini App → фронт обменивает подписанный `initData`
+   на нашу сессию через `POST /auth/telegram` — без форм и паролей; первый
+   визит создаёт пользователя (привязка по `telegram_id`).
+5. Menu button бота (Bot Settings → Menu Button) — «Играть» с тем же URL.
 
 Регистрация по email в проде выключена (`AUTH_EMAIL_SIGNUP_ENABLED: "false"`
 в `docker-compose.prod.yml`) — это локально-тестовый способ входа. Логин
-существующих аккаунтов при этом работает. После появления Telegram-входа
-фронт переключится на него; флаг отдаётся клиенту через `GET /config`.
+существующих аккаунтов при этом работает. Флаг отдаётся клиенту через
+`GET /config`.
 
 ## Чего в этом контуре сознательно нет
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Балда — мультиплеерная словесная игра" />
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>Балда</title>
   </head>
   <body>

--- a/frontend/src/components/AuthForm.svelte
+++ b/frontend/src/components/AuthForm.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { auth, signup, setTokens, getConfig } from '../lib/api';
+  import { auth, signup, setTokens, getConfig, authTelegram } from '../lib/api';
   import { centrifugo } from '../lib/centrifugo';
   import { gameState } from '../stores/game.svelte';
+  import { isMiniApp, getTelegramInitData, initMiniApp } from '../lib/telegram';
   import type { AuthResponse, SignupResponse } from '../types';
 
   let isSignup = $state(false);
@@ -12,6 +13,59 @@
   let lastname = $state('');
   let error = $state('');
   let loading = $state(false);
+  let telegramError = $state('');
+
+  const miniApp = isMiniApp();
+
+  function applyAuthResponse(res: AuthResponse | SignupResponse) {
+    const player = 'player' in res ? res.player : res.user;
+    setTokens(res.access_token || '', res.refresh_token || '');
+    gameState.setAuth({
+      playerUid: player.uid,
+      nickname: player.firstname,
+      exp: player.exp ?? 0,
+      rating: player.rating ?? 0,
+      centrifugoToken: res.centrifugo_token || '',
+      lobbyToken: res.lobby_token || '',
+    });
+
+    // Restore an active game after reconnect (e.g. page refresh). The backend
+    // returns the game token and snapshot so the player can rejoin without
+    // being stuck in the lobby with a "player already in a game" conflict.
+    const activeGame = 'active_game' in res ? res.active_game : undefined;
+    if (activeGame?.game_id && activeGame.game_token) {
+      centrifugo.subscribe(`game:${activeGame.game_id}`, activeGame.game_token);
+      const playerIds = activeGame.players?.map((p) => p.uid) ?? [];
+      if (activeGame.status === 'waiting') {
+        gameState.setWaiting({
+          id: activeGame.game_id,
+          player_ids: playerIds,
+          status: 'waiting',
+          started_at: 0,
+        });
+      } else {
+        gameState.startGame({
+          id: activeGame.game_id,
+          player_ids: playerIds,
+          status: activeGame.status || 'in_progress',
+          started_at: 0,
+        });
+        if (activeGame.board && activeGame.current_turn_uid) {
+          gameState.applyGameState({
+            type: 'game_state',
+            game_id: activeGame.game_id,
+            board: activeGame.board,
+            current_turn_uid: activeGame.current_turn_uid,
+            players: activeGame.players ?? [],
+            status: activeGame.status || 'in_progress',
+            move_number: activeGame.move_number ?? 0,
+          });
+        }
+      }
+    } else {
+      gameState.setLobby();
+    }
+  }
 
   // Registration may be disabled by the server (prod: Telegram-only sign-up,
   // email stays for local testing). Login remains available either way.
@@ -19,6 +73,19 @@
     getConfig()
       .then((cfg) => (signupEnabled = cfg.email_signup_enabled))
       .catch(() => {});
+  });
+
+  // Inside the Telegram WebView there is no form at all: the signed init data
+  // is exchanged for our session right away.
+  $effect(() => {
+    const initData = getTelegramInitData();
+    if (!initData) return;
+    initMiniApp();
+    authTelegram(initData)
+      .then(applyAuthResponse)
+      .catch((e) => {
+        telegramError = e instanceof Error ? e.message : 'Ошибка входа через Telegram';
+      });
   });
 
   async function handleSubmit(e: Event) {
@@ -33,54 +100,7 @@
       } else {
         res = await auth({ email, password });
       }
-
-      const player = 'player' in res ? res.player : res.user;
-      setTokens(res.access_token || '', res.refresh_token || '');
-      gameState.setAuth({
-        playerUid: player.uid,
-        nickname: player.firstname,
-        exp: player.exp ?? 0,
-        rating: player.rating ?? 0,
-        centrifugoToken: res.centrifugo_token || '',
-        lobbyToken: res.lobby_token || '',
-      });
-
-      // Restore an active game after reconnect (e.g. page refresh). The backend
-      // returns the game token and snapshot so the player can rejoin without
-      // being stuck in the lobby with a "player already in a game" conflict.
-      const activeGame = 'active_game' in res ? res.active_game : undefined;
-      if (activeGame?.game_id && activeGame.game_token) {
-        centrifugo.subscribe(`game:${activeGame.game_id}`, activeGame.game_token);
-        const playerIds = activeGame.players?.map((p) => p.uid) ?? [];
-        if (activeGame.status === 'waiting') {
-          gameState.setWaiting({
-            id: activeGame.game_id,
-            player_ids: playerIds,
-            status: 'waiting',
-            started_at: 0,
-          });
-        } else {
-          gameState.startGame({
-            id: activeGame.game_id,
-            player_ids: playerIds,
-            status: activeGame.status || 'in_progress',
-            started_at: 0,
-          });
-          if (activeGame.board && activeGame.current_turn_uid) {
-            gameState.applyGameState({
-              type: 'game_state',
-              game_id: activeGame.game_id,
-              board: activeGame.board,
-              current_turn_uid: activeGame.current_turn_uid,
-              players: activeGame.players ?? [],
-              status: activeGame.status || 'in_progress',
-              move_number: activeGame.move_number ?? 0,
-            });
-          }
-        }
-      } else {
-        gameState.setLobby();
-      }
+      applyAuthResponse(res);
     } catch (err: any) {
       error = err.message || 'Ошибка авторизации';
     } finally {
@@ -90,65 +110,74 @@
 </script>
 
 <div class="mx-auto w-full max-w-sm rounded-2xl bg-white p-6 shadow-lg">
-  <h2 class="mb-4 text-center text-2xl font-bold text-stone-800">
-    {isSignup ? 'Регистрация' : 'Вход в игру'}
-  </h2>
+  {#if miniApp}
+    <h2 class="mb-4 text-center text-2xl font-bold text-stone-800">Балда</h2>
+    {#if telegramError}
+      <div class="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{telegramError}</div>
+    {:else}
+      <div class="py-8 text-center text-stone-500">Входим через Telegram…</div>
+    {/if}
+  {:else}
+    <h2 class="mb-4 text-center text-2xl font-bold text-stone-800">
+      {isSignup ? 'Регистрация' : 'Вход в игру'}
+    </h2>
 
-  <form onsubmit={handleSubmit} class="flex flex-col gap-3">
-    {#if isSignup}
+    <form onsubmit={handleSubmit} class="flex flex-col gap-3">
+      {#if isSignup}
+        <input
+          type="text"
+          placeholder="Имя"
+          bind:value={firstname}
+          required
+          class="rounded-xl border border-stone-200 px-4 py-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+        />
+        <input
+          type="text"
+          placeholder="Фамилия"
+          bind:value={lastname}
+          required
+          class="rounded-xl border border-stone-200 px-4 py-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+        />
+      {/if}
       <input
-        type="text"
-        placeholder="Имя"
-        bind:value={firstname}
+        type="email"
+        placeholder="Email"
+        bind:value={email}
         required
         class="rounded-xl border border-stone-200 px-4 py-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
       />
       <input
-        type="text"
-        placeholder="Фамилия"
-        bind:value={lastname}
+        type="password"
+        placeholder="Пароль"
+        bind:value={password}
         required
         class="rounded-xl border border-stone-200 px-4 py-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
       />
-    {/if}
-    <input
-      type="email"
-      placeholder="Email"
-      bind:value={email}
-      required
-      class="rounded-xl border border-stone-200 px-4 py-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-    />
-    <input
-      type="password"
-      placeholder="Пароль"
-      bind:value={password}
-      required
-      class="rounded-xl border border-stone-200 px-4 py-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
-    />
 
-    {#if error}
-      <div class="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>
-    {/if}
+      {#if error}
+        <div class="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>
+      {/if}
+
+      <button
+        type="submit"
+        disabled={loading}
+        class="mt-2 rounded-xl bg-blue-600 px-4 py-3 font-bold text-white transition hover:bg-blue-700 disabled:opacity-50"
+      >
+        {loading ? 'Загрузка...' : isSignup ? 'Зарегистрироваться' : 'Войти'}
+      </button>
+    </form>
 
     <button
-      type="submit"
-      disabled={loading}
-      class="mt-2 rounded-xl bg-blue-600 px-4 py-3 font-bold text-white transition hover:bg-blue-700 disabled:opacity-50"
+      type="button"
+      onclick={() => (isSignup = !isSignup)}
+      class="mt-4 w-full text-center text-sm text-stone-500 hover:text-stone-700 {signupEnabled ? '' : 'hidden'}"
     >
-      {loading ? 'Загрузка...' : isSignup ? 'Зарегистрироваться' : 'Войти'}
+      {isSignup ? 'Уже есть аккаунт? Войти' : 'Нет аккаунта? Зарегистрироваться'}
     </button>
-  </form>
-
-  <button
-    type="button"
-    onclick={() => (isSignup = !isSignup)}
-    class="mt-4 w-full text-center text-sm text-stone-500 hover:text-stone-700 {signupEnabled ? '' : 'hidden'}"
-  >
-    {isSignup ? 'Уже есть аккаунт? Войти' : 'Нет аккаунта? Зарегистрироваться'}
-  </button>
-  {#if !signupEnabled}
-    <div class="mt-4 text-center text-sm text-stone-400">
-      Регистрация по email закрыта — скоро вход через Telegram
-    </div>
+    {#if !signupEnabled}
+      <div class="mt-4 text-center text-sm text-stone-400">
+        Регистрация по email закрыта — откройте игру в Telegram
+      </div>
+    {/if}
   {/if}
 </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -108,6 +108,10 @@ export function auth(data: AuthRequest): Promise<AuthResponse> {
   return apiFetch('/auth', { method: 'POST', body: JSON.stringify(data) }, false);
 }
 
+export function authTelegram(initData: string): Promise<AuthResponse> {
+  return apiFetch('/auth/telegram', { method: 'POST', body: JSON.stringify({ init_data: initData }) }, false);
+}
+
 export function refresh(): Promise<RefreshResponse> {
   return apiFetch('/auth/refresh', {
     method: 'POST',

--- a/frontend/src/lib/telegram.ts
+++ b/frontend/src/lib/telegram.ts
@@ -1,0 +1,40 @@
+// Thin wrapper around the Telegram Mini App JS API. Outside the Telegram
+// WebView the global is absent and every helper degrades to a no-op.
+
+interface TelegramWebApp {
+  initData: string;
+  ready(): void;
+  expand(): void;
+}
+
+interface TelegramWindow extends Window {
+  Telegram?: { WebApp?: TelegramWebApp };
+}
+
+function webApp(): TelegramWebApp | null {
+  return (window as TelegramWindow).Telegram?.WebApp ?? null;
+}
+
+// isMiniApp reports whether the page runs inside the Telegram WebView with
+// signed init data available (empty string means the app was opened outside
+// a bot context).
+export function isMiniApp(): boolean {
+  const app = webApp();
+  return !!app && app.initData.length > 0;
+}
+
+// getTelegramInitData returns the signed init data to send to the backend,
+// or null when not running as a Mini App.
+export function getTelegramInitData(): string | null {
+  const app = webApp();
+  return app && app.initData.length > 0 ? app.initData : null;
+}
+
+// initMiniApp tells Telegram the app is ready and asks for the full-height
+// layout. Safe to call outside the WebView.
+export function initMiniApp(): void {
+  const app = webApp();
+  if (!app) return;
+  app.ready();
+  app.expand();
+}

--- a/internal/auth/telegram.go
+++ b/internal/auth/telegram.go
@@ -1,0 +1,103 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// TelegramUser holds the user fields extracted from validated Telegram
+// Mini App init data.
+type TelegramUser struct {
+	ID        int64
+	FirstName string
+	LastName  string
+	Username  string
+}
+
+// ErrTelegramInitData is returned when Telegram init data fails validation:
+// malformed input, bad signature, expired auth_date or missing user payload.
+var ErrTelegramInitData = errors.New("auth: invalid telegram init data")
+
+// ValidateInitData verifies Telegram Mini App init data against the bot token
+// and returns the embedded user. maxAge bounds the auth_date freshness.
+//
+// The check follows https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app:
+// the data-check-string is every key=value pair except "hash", sorted by key
+// and joined with '\n'; the secret key is HMAC-SHA256("WebAppData", botToken);
+// the signature is HMAC-SHA256(dataCheckString, secret) as hex.
+func ValidateInitData(initData, botToken string, maxAge time.Duration) (TelegramUser, error) {
+	vals, err := url.ParseQuery(initData)
+	if err != nil {
+		return TelegramUser{}, fmt.Errorf("%w: parse: %w", ErrTelegramInitData, err)
+	}
+
+	hash := vals.Get("hash")
+	if hash == "" {
+		return TelegramUser{}, fmt.Errorf("%w: no hash", ErrTelegramInitData)
+	}
+
+	pairs := make([]string, 0, len(vals))
+	for key, values := range vals {
+		if key == "hash" {
+			continue
+		}
+		for _, v := range values {
+			pairs = append(pairs, key+"="+v)
+		}
+	}
+	sort.Strings(pairs)
+	dataCheckString := strings.Join(pairs, "\n")
+
+	secretMAC := hmac.New(sha256.New, []byte("WebAppData"))
+	secretMAC.Write([]byte(botToken))
+	secret := secretMAC.Sum(nil)
+
+	sigMAC := hmac.New(sha256.New, secret)
+	sigMAC.Write([]byte(dataCheckString))
+	expected := hex.EncodeToString(sigMAC.Sum(nil))
+
+	if !hmac.Equal([]byte(expected), []byte(hash)) {
+		return TelegramUser{}, fmt.Errorf("%w: bad signature", ErrTelegramInitData)
+	}
+
+	authDate, err := strconv.ParseInt(vals.Get("auth_date"), 10, 64)
+	if err != nil {
+		return TelegramUser{}, fmt.Errorf("%w: bad auth_date", ErrTelegramInitData)
+	}
+	if age := time.Since(time.Unix(authDate, 0)); age > maxAge || age < -time.Minute {
+		return TelegramUser{}, fmt.Errorf("%w: expired", ErrTelegramInitData)
+	}
+
+	userJSON := vals.Get("user")
+	if userJSON == "" {
+		return TelegramUser{}, fmt.Errorf("%w: no user", ErrTelegramInitData)
+	}
+	var u struct {
+		ID        int64  `json:"id"`
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		Username  string `json:"username"`
+	}
+	if err := json.Unmarshal([]byte(userJSON), &u); err != nil {
+		return TelegramUser{}, fmt.Errorf("%w: bad user payload", ErrTelegramInitData)
+	}
+	if u.ID == 0 || u.FirstName == "" {
+		return TelegramUser{}, fmt.Errorf("%w: incomplete user payload", ErrTelegramInitData)
+	}
+
+	return TelegramUser{
+		ID:        u.ID,
+		FirstName: u.FirstName,
+		LastName:  u.LastName,
+		Username:  u.Username,
+	}, nil
+}

--- a/internal/auth/telegram_test.go
+++ b/internal/auth/telegram_test.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testBotToken = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+// buildInitData constructs a correctly signed init data string for tests.
+func buildInitData(t *testing.T, fields map[string]string) string {
+	t.Helper()
+
+	pairs := make([]string, 0, len(fields))
+	for k, v := range fields {
+		pairs = append(pairs, k+"="+v)
+	}
+	sort.Strings(pairs)
+	dataCheckString := strings.Join(pairs, "\n")
+
+	secretMAC := hmac.New(sha256.New, []byte("WebAppData"))
+	secretMAC.Write([]byte(testBotToken))
+	sigMAC := hmac.New(sha256.New, secretMAC.Sum(nil))
+	sigMAC.Write([]byte(dataCheckString))
+
+	q := url.Values{}
+	for k, v := range fields {
+		q.Set(k, v)
+	}
+	q.Set("hash", hex.EncodeToString(sigMAC.Sum(nil)))
+	return q.Encode()
+}
+
+func validFields() map[string]string {
+	return map[string]string{
+		"auth_date": strconv.FormatInt(time.Now().Unix(), 10),
+		"query_id":  "AAHdF6IQAAAAAN0XohDhrOrc",
+		"user":      `{"id":279058397,"first_name":"Vladislav","last_name":"Kibenko","username":"vdkfrost"}`,
+	}
+}
+
+func TestValidateInitData_Valid(t *testing.T) {
+	u, err := ValidateInitData(buildInitData(t, validFields()), testBotToken, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, int64(279058397), u.ID)
+	assert.Equal(t, "Vladislav", u.FirstName)
+	assert.Equal(t, "Kibenko", u.LastName)
+	assert.Equal(t, "vdkfrost", u.Username)
+}
+
+func TestValidateInitData_TamperedField(t *testing.T) {
+	fields := validFields()
+	fields["user"] = `{"id":1,"first_name":"Mallory","last_name":"","username":"mallory"}`
+	// Sign with the original fields, then swap in the tampered user payload.
+	initData := buildInitData(t, validFields())
+	tampered := strings.Replace(initData,
+		url.QueryEscape(validFields()["user"]),
+		url.QueryEscape(fields["user"]), 1)
+	require.NotEqual(t, initData, tampered)
+
+	_, err := ValidateInitData(tampered, testBotToken, 24*time.Hour)
+	assert.ErrorIs(t, err, ErrTelegramInitData)
+}
+
+func TestValidateInitData_WrongBotToken(t *testing.T) {
+	_, err := ValidateInitData(buildInitData(t, validFields()), "999:wrong-token", 24*time.Hour)
+	assert.ErrorIs(t, err, ErrTelegramInitData)
+}
+
+func TestValidateInitData_Expired(t *testing.T) {
+	fields := validFields()
+	fields["auth_date"] = strconv.FormatInt(time.Now().Add(-48*time.Hour).Unix(), 10)
+	_, err := ValidateInitData(buildInitData(t, fields), testBotToken, 24*time.Hour)
+	assert.ErrorIs(t, err, ErrTelegramInitData)
+}
+
+func TestValidateInitData_Malformed(t *testing.T) {
+	cases := map[string]string{
+		"empty":        "",
+		"garbage":      "%%%",
+		"no hash":      "auth_date=123&user=%7B%7D",
+		"no auth_date": buildInitData(t, map[string]string{"user": `{"id":1,"first_name":"A"}`}),
+		"no user": buildInitData(t, map[string]string{
+			"auth_date": strconv.FormatInt(time.Now().Unix(), 10),
+		}),
+	}
+	for name, initData := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := ValidateInitData(initData, testBotToken, 24*time.Hour)
+			assert.ErrorIs(t, err, ErrTelegramInitData, fmt.Sprintf("input %q", initData))
+		})
+	}
+}

--- a/internal/server/ogen/oas_client_gen.go
+++ b/internal/server/ogen/oas_client_gen.go
@@ -42,6 +42,13 @@ type Invoker interface {
 	//
 	// POST /auth
 	Auth(ctx context.Context, request *AuthRequest) (AuthRes, error)
+	// AuthTelegram invokes authTelegram operation.
+	//
+	// Validates the signed init data produced by the Telegram WebView against the bot token, then logs in
+	// an existing user or creates a new one linked to their Telegram account.
+	//
+	// POST /auth/telegram
+	AuthTelegram(ctx context.Context, request *TelegramAuthRequest) (AuthTelegramRes, error)
 	// CreateGame invokes createGame operation.
 	//
 	// Create a new game.
@@ -407,6 +414,90 @@ func (c *Client) sendAuth(ctx context.Context, request *AuthRequest) (res AuthRe
 
 	stage = "DecodeResponse"
 	result, err := decodeAuthResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// AuthTelegram invokes authTelegram operation.
+//
+// Validates the signed init data produced by the Telegram WebView against the bot token, then logs in
+// an existing user or creates a new one linked to their Telegram account.
+//
+// POST /auth/telegram
+func (c *Client) AuthTelegram(ctx context.Context, request *TelegramAuthRequest) (AuthTelegramRes, error) {
+	res, err := c.sendAuthTelegram(ctx, request)
+	return res, err
+}
+
+func (c *Client) sendAuthTelegram(ctx context.Context, request *TelegramAuthRequest) (res AuthTelegramRes, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("authTelegram"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.URLTemplateKey.String("/auth/telegram"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, AuthTelegramOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/auth/telegram"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+	if err := encodeAuthTelegramRequest(request, r); err != nil {
+		return res, errors.Wrap(err, "encode request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer func() {
+		// Drain the body to EOF before closing, so the underlying
+		// connection can be reused by the Transport regardless of the
+		// response status code. See https://github.com/ogen-go/ogen/issues/1670.
+		_, _ = io.Copy(io.Discard, body)
+		_ = body.Close()
+	}()
+
+	stage = "DecodeResponse"
+	result, err := decodeAuthTelegramResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/internal/server/ogen/oas_handlers_gen.go
+++ b/internal/server/ogen/oas_handlers_gen.go
@@ -364,6 +364,150 @@ func (s *Server) handleAuthRequest(args [0]string, argsEscaped bool, w http.Resp
 	}
 }
 
+// handleAuthTelegramRequest handles authTelegram operation.
+//
+// Validates the signed init data produced by the Telegram WebView against the bot token, then logs in
+// an existing user or creates a new one linked to their Telegram account.
+//
+// POST /auth/telegram
+func (s *Server) handleAuthTelegramRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("authTelegram"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/auth/telegram"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), AuthTelegramOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(attrs...)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: AuthTelegramOperation,
+			ID:   "authTelegram",
+		}
+	)
+
+	var rawBody []byte
+	request, rawBody, close, err := s.decodeAuthTelegramRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response AuthTelegramRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    AuthTelegramOperation,
+			OperationSummary: "Authenticate via Telegram Mini App init data",
+			OperationID:      "authTelegram",
+			Body:             request,
+			RawBody:          rawBody,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = *TelegramAuthRequest
+			Params   = struct{}
+			Response = AuthTelegramRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.AuthTelegram(ctx, request)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.AuthTelegram(ctx, request)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeAuthTelegramResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleCreateGameRequest handles createGame operation.
 //
 // Create a new game.

--- a/internal/server/ogen/oas_interfaces_gen.go
+++ b/internal/server/ogen/oas_interfaces_gen.go
@@ -9,6 +9,10 @@ type AuthRes interface {
 	authRes()
 }
 
+type AuthTelegramRes interface {
+	authTelegramRes()
+}
+
 type CreateGameRes interface {
 	createGameRes()
 }

--- a/internal/server/ogen/oas_json_gen.go
+++ b/internal/server/ogen/oas_json_gen.go
@@ -825,6 +825,120 @@ func (s *AuthResponse) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes AuthTelegramInternalServerError as json.
+func (s *AuthTelegramInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes AuthTelegramInternalServerError from json.
+func (s *AuthTelegramInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AuthTelegramInternalServerError to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = AuthTelegramInternalServerError(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AuthTelegramInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AuthTelegramInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AuthTelegramServiceUnavailable as json.
+func (s *AuthTelegramServiceUnavailable) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes AuthTelegramServiceUnavailable from json.
+func (s *AuthTelegramServiceUnavailable) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AuthTelegramServiceUnavailable to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = AuthTelegramServiceUnavailable(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AuthTelegramServiceUnavailable) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AuthTelegramServiceUnavailable) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AuthTelegramUnauthorized as json.
+func (s *AuthTelegramUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes AuthTelegramUnauthorized from json.
+func (s *AuthTelegramUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AuthTelegramUnauthorized to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = AuthTelegramUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AuthTelegramUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AuthTelegramUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode implements json.Marshaler.
 func (s *BoardCell) Encode(e *jx.Encoder) {
 	e.ObjStart()
@@ -5516,6 +5630,102 @@ func (s *SkipGameUnauthorized) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *SkipGameUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *TelegramAuthRequest) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *TelegramAuthRequest) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("init_data")
+		e.Str(s.InitData)
+	}
+}
+
+var jsonFieldsNameOfTelegramAuthRequest = [1]string{
+	0: "init_data",
+}
+
+// Decode decodes TelegramAuthRequest from json.
+func (s *TelegramAuthRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode TelegramAuthRequest to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "init_data":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.InitData = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"init_data\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode TelegramAuthRequest")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfTelegramAuthRequest) {
+					name = jsonFieldsNameOfTelegramAuthRequest[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *TelegramAuthRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *TelegramAuthRequest) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/internal/server/ogen/oas_operations_gen.go
+++ b/internal/server/ogen/oas_operations_gen.go
@@ -8,6 +8,7 @@ type OperationName = string
 const (
 	AcceptEndGameOperation         OperationName = "AcceptEndGame"
 	AuthOperation                  OperationName = "Auth"
+	AuthTelegramOperation          OperationName = "AuthTelegram"
 	CreateGameOperation            OperationName = "CreateGame"
 	CreateGameWithBotOperation     OperationName = "CreateGameWithBot"
 	GetConfigOperation             OperationName = "GetConfig"

--- a/internal/server/ogen/oas_request_decoders_gen.go
+++ b/internal/server/ogen/oas_request_decoders_gen.go
@@ -85,6 +85,77 @@ func (s *Server) decodeAuthRequest(r *http.Request) (
 	}
 }
 
+func (s *Server) decodeAuthTelegramRequest(r *http.Request) (
+	req *TelegramAuthRequest,
+	rawBody []byte,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = errors.Join(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = errors.Join(rerr, close())
+		}
+	}()
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, rawBody, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, rawBody, close, validate.ErrBodyRequired
+		}
+		buf, err := io.ReadAll(r.Body)
+		defer func() {
+			_ = r.Body.Close()
+		}()
+		if err != nil {
+			return req, rawBody, close, err
+		}
+
+		// Reset the body to allow for downstream reading.
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
+
+		if len(buf) == 0 {
+			return req, rawBody, close, validate.ErrBodyRequired
+		}
+
+		rawBody = append(rawBody, buf...)
+		d := jx.DecodeBytes(buf)
+
+		var request TelegramAuthRequest
+		if err := func() error {
+			if err := request.Decode(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, rawBody, close, err
+		}
+		return &request, rawBody, close, nil
+	default:
+		return req, rawBody, close, validate.InvalidContentType(ct)
+	}
+}
+
 func (s *Server) decodeLogoutRequest(r *http.Request) (
 	req OptLogoutRequest,
 	rawBody []byte,

--- a/internal/server/ogen/oas_request_encoders_gen.go
+++ b/internal/server/ogen/oas_request_encoders_gen.go
@@ -24,6 +24,20 @@ func encodeAuthRequest(
 	return nil
 }
 
+func encodeAuthTelegramRequest(
+	req *TelegramAuthRequest,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	e := new(jx.Encoder)
+	{
+		req.Encode(e)
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
 func encodeLogoutRequest(
 	req OptLogoutRequest,
 	r *http.Request,

--- a/internal/server/ogen/oas_response_decoders_gen.go
+++ b/internal/server/ogen/oas_response_decoders_gen.go
@@ -249,6 +249,161 @@ func decodeAuthResponse(resp *http.Response) (res AuthRes, _ error) {
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
+func decodeAuthTelegramResponse(resp *http.Response) (res AuthTelegramRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response AuthResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			// Validate response.
+			if err := func() error {
+				if err := response.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 401:
+		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response AuthTelegramUnauthorized
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response AuthTelegramInternalServerError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 503:
+		// Code 503.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response AuthTelegramServiceUnavailable
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
 func decodeCreateGameResponse(resp *http.Response) (res CreateGameRes, _ error) {
 	switch resp.StatusCode {
 	case 200:

--- a/internal/server/ogen/oas_response_encoders_gen.go
+++ b/internal/server/ogen/oas_response_encoders_gen.go
@@ -104,6 +104,63 @@ func encodeAuthResponse(response AuthRes, w http.ResponseWriter, span trace.Span
 	}
 }
 
+func encodeAuthTelegramResponse(response AuthTelegramRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *AuthResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *AuthTelegramUnauthorized:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(401)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *AuthTelegramInternalServerError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *AuthTelegramServiceUnavailable:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(503)
+		span.SetStatus(codes.Error, http.StatusText(503))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodeCreateGameResponse(response CreateGameRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *CreateGameResponse:

--- a/internal/server/ogen/oas_router_gen.go
+++ b/internal/server/ogen/oas_router_gen.go
@@ -14,50 +14,53 @@ var (
 	rn5AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
-	rn18AllowedHeaders = map[string]string{
+	rn20AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type",
 	}
-	rn23AllowedHeaders = map[string]string{
+	rn24AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
 	rn6AllowedHeaders = map[string]string{
+		"POST": "Content-Type",
+	}
+	rn7AllowedHeaders = map[string]string{
 		"GET":  "Authorization",
 		"POST": "Authorization",
 	}
-	rn7AllowedHeaders = map[string]string{
+	rn8AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
 	rn3AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn17AllowedHeaders = map[string]string{
+	rn18AllowedHeaders = map[string]string{
 		"POST": "Authorization",
-	}
-	rn19AllowedHeaders = map[string]string{
-		"POST": "Authorization,Content-Type",
 	}
 	rn21AllowedHeaders = map[string]string{
+		"POST": "Authorization,Content-Type",
+	}
+	rn23AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn24AllowedHeaders = map[string]string{
+	rn25AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn27AllowedHeaders = map[string]string{
+	rn28AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn10AllowedHeaders = map[string]string{
+	rn11AllowedHeaders = map[string]string{
 		"GET": "Authorization",
 	}
-	rn13AllowedHeaders = map[string]string{
+	rn14AllowedHeaders = map[string]string{
 		"GET": "Authorization",
 	}
-	rn15AllowedHeaders = map[string]string{
+	rn16AllowedHeaders = map[string]string{
 		"GET": "Authorization",
 	}
-	rn20AllowedHeaders = map[string]string{
+	rn22AllowedHeaders = map[string]string{
 		"POST": "Authorization,X-Request-Id",
 	}
-	rn26AllowedHeaders = map[string]string{
+	rn27AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
 )
@@ -165,7 +168,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn18AllowedHeaders,
+									allowedHeaders: rn20AllowedHeaders,
 									acceptPost:     "application/json",
 									acceptPatch:    "",
 								})
@@ -190,7 +193,32 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn23AllowedHeaders,
+									allowedHeaders: rn24AllowedHeaders,
+									acceptPost:     "application/json",
+									acceptPatch:    "",
+								})
+							}
+
+							return
+						}
+
+					case 't': // Prefix: "telegram"
+
+						if l := len("telegram"); len(elem) >= l && elem[0:l] == "telegram" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch r.Method {
+							case "POST":
+								s.handleAuthTelegramRequest([0]string{}, elemIsEscaped, w, r)
+							default:
+								s.notAllowed(w, r, notAllowedParams{
+									allowedMethods: "POST",
+									allowedHeaders: rn6AllowedHeaders,
 									acceptPost:     "application/json",
 									acceptPatch:    "",
 								})
@@ -245,7 +273,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					default:
 						s.notAllowed(w, r, notAllowedParams{
 							allowedMethods: "GET,POST",
-							allowedHeaders: rn6AllowedHeaders,
+							allowedHeaders: rn7AllowedHeaders,
 							acceptPost:     "",
 							acceptPatch:    "",
 						})
@@ -282,7 +310,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn7AllowedHeaders,
+									allowedHeaders: rn8AllowedHeaders,
 									acceptPost:     "",
 									acceptPatch:    "",
 								})
@@ -363,7 +391,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn17AllowedHeaders,
+										allowedHeaders: rn18AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -390,7 +418,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn19AllowedHeaders,
+										allowedHeaders: rn21AllowedHeaders,
 										acceptPost:     "application/json",
 										acceptPatch:    "",
 									})
@@ -417,7 +445,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn21AllowedHeaders,
+										allowedHeaders: rn23AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -444,7 +472,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn24AllowedHeaders,
+										allowedHeaders: rn25AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -471,7 +499,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn27AllowedHeaders,
+										allowedHeaders: rn28AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -539,7 +567,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "GET",
-								allowedHeaders: rn10AllowedHeaders,
+								allowedHeaders: rn11AllowedHeaders,
 								acceptPost:     "",
 								acceptPatch:    "",
 							})
@@ -587,7 +615,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "GET",
-									allowedHeaders: rn13AllowedHeaders,
+									allowedHeaders: rn14AllowedHeaders,
 									acceptPost:     "",
 									acceptPatch:    "",
 								})
@@ -612,7 +640,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "GET",
-									allowedHeaders: rn15AllowedHeaders,
+									allowedHeaders: rn16AllowedHeaders,
 									acceptPost:     "",
 									acceptPatch:    "",
 								})
@@ -653,7 +681,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn20AllowedHeaders,
+								allowedHeaders: rn22AllowedHeaders,
 								acceptPost:     "",
 								acceptPatch:    "",
 							})
@@ -678,7 +706,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn26AllowedHeaders,
+								allowedHeaders: rn27AllowedHeaders,
 								acceptPost:     "application/json",
 								acceptPatch:    "",
 							})
@@ -867,6 +895,31 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 								r.operationID = "refreshToken"
 								r.operationGroup = ""
 								r.pathPattern = "/auth/refresh"
+								r.args = args
+								r.count = 0
+								return r, true
+							default:
+								return
+							}
+						}
+
+					case 't': // Prefix: "telegram"
+
+						if l := len("telegram"); len(elem) >= l && elem[0:l] == "telegram" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch method {
+							case "POST":
+								r.name = AuthTelegramOperation
+								r.summary = "Authenticate via Telegram Mini App init data"
+								r.operationID = "authTelegram"
+								r.operationGroup = ""
+								r.pathPattern = "/auth/telegram"
 								r.args = args
 								r.count = 0
 								return r, true

--- a/internal/server/ogen/oas_schemas_gen.go
+++ b/internal/server/ogen/oas_schemas_gen.go
@@ -369,7 +369,20 @@ func (s *AuthResponse) SetActiveGame(val OptActiveGame) {
 	s.ActiveGame = val
 }
 
-func (*AuthResponse) authRes() {}
+func (*AuthResponse) authRes()         {}
+func (*AuthResponse) authTelegramRes() {}
+
+type AuthTelegramInternalServerError ErrorResponse
+
+func (*AuthTelegramInternalServerError) authTelegramRes() {}
+
+type AuthTelegramServiceUnavailable ErrorResponse
+
+func (*AuthTelegramServiceUnavailable) authTelegramRes() {}
+
+type AuthTelegramUnauthorized ErrorResponse
+
+func (*AuthTelegramUnauthorized) authTelegramRes() {}
 
 type BearerAuth struct {
 	Token string
@@ -2616,3 +2629,19 @@ func (*SkipGameNotFound) skipGameRes() {}
 type SkipGameUnauthorized ErrorResponse
 
 func (*SkipGameUnauthorized) skipGameRes() {}
+
+// Ref: #/components/schemas/TelegramAuthRequest
+type TelegramAuthRequest struct {
+	// Raw init data string provided by the Telegram WebView (window.Telegram.WebApp.initData).
+	InitData string `json:"init_data"`
+}
+
+// GetInitData returns the value of InitData.
+func (s *TelegramAuthRequest) GetInitData() string {
+	return s.InitData
+}
+
+// SetInitData sets the value of InitData.
+func (s *TelegramAuthRequest) SetInitData(val string) {
+	s.InitData = val
+}

--- a/internal/server/ogen/oas_server_gen.go
+++ b/internal/server/ogen/oas_server_gen.go
@@ -21,6 +21,13 @@ type Handler interface {
 	//
 	// POST /auth
 	Auth(ctx context.Context, req *AuthRequest) (AuthRes, error)
+	// AuthTelegram implements authTelegram operation.
+	//
+	// Validates the signed init data produced by the Telegram WebView against the bot token, then logs in
+	// an existing user or creates a new one linked to their Telegram account.
+	//
+	// POST /auth/telegram
+	AuthTelegram(ctx context.Context, req *TelegramAuthRequest) (AuthTelegramRes, error)
 	// CreateGame implements createGame operation.
 	//
 	// Create a new game.

--- a/internal/server/ogen/oas_unimplemented_gen.go
+++ b/internal/server/ogen/oas_unimplemented_gen.go
@@ -32,6 +32,16 @@ func (UnimplementedHandler) Auth(ctx context.Context, req *AuthRequest) (r AuthR
 	return r, ht.ErrNotImplemented
 }
 
+// AuthTelegram implements authTelegram operation.
+//
+// Validates the signed init data produced by the Telegram WebView against the bot token, then logs in
+// an existing user or creates a new one linked to their Telegram account.
+//
+// POST /auth/telegram
+func (UnimplementedHandler) AuthTelegram(ctx context.Context, req *TelegramAuthRequest) (r AuthTelegramRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // CreateGame implements createGame operation.
 //
 // Create a new game.

--- a/internal/server/restapi/handlers/auth.go
+++ b/internal/server/restapi/handlers/auth.go
@@ -36,23 +36,34 @@ func (h *Handlers) Auth(ctx context.Context, req *baldaapi.AuthRequest) (baldaap
 		}, nil
 	}
 
+	resp, errResp := h.newAuthResponse(ctx, u)
+	if errResp != nil {
+		return errResp, nil
+	}
+	return resp, nil
+}
+
+// newAuthResponse builds a full AuthResponse (JWT pair, centrifugo tokens,
+// optional active game snapshot) for an already-identified user. It is shared
+// by the email/password and Telegram auth handlers.
+func (h *Handlers) newAuthResponse(ctx context.Context, u storage.UserAuth) (*baldaapi.AuthResponse, *baldaapi.ErrorResponse) {
 	access, refresh, err := h.issueTokens(ctx, u.UID, u.PlayerID, u.Role, "", "")
 	if err != nil {
 		slog.Error("auth: issue tokens", slog.Any("error", err))
-		return &baldaapi.ErrorResponse{
+		return nil, &baldaapi.ErrorResponse{
 			Message: baldaapi.NewOptString("internal error"),
 			Status:  baldaapi.NewOptInt(http.StatusInternalServerError),
 			Type:    baldaapi.NewOptString("InternalServerError"),
-		}, nil
+		}
 	}
 
 	cfToken, lobbyToken, err := h.generateCentrifugoTokens(u.UID)
 	if err != nil {
-		return &baldaapi.ErrorResponse{
+		return nil, &baldaapi.ErrorResponse{
 			Message: baldaapi.NewOptString("internal error"),
 			Status:  baldaapi.NewOptInt(http.StatusInternalServerError),
 			Type:    baldaapi.NewOptString("InternalServerError"),
-		}, nil
+		}
 	}
 
 	resp := &baldaapi.AuthResponse{

--- a/internal/server/restapi/handlers/auth_telegram.go
+++ b/internal/server/restapi/handlers/auth_telegram.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/rustwizard/balda/internal/auth"
+	"github.com/rustwizard/balda/internal/flname"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+	"github.com/rustwizard/balda/internal/storage"
+)
+
+// telegramInitDataMaxAge bounds how old the Telegram init data may be.
+const telegramInitDataMaxAge = 24 * time.Hour
+
+// AuthTelegram implements baldaapi.Handler. It validates Telegram Mini App
+// init data against the bot token, then logs in the linked user or creates a
+// new one on first visit.
+func (h *Handlers) AuthTelegram(ctx context.Context, req *baldaapi.TelegramAuthRequest) (baldaapi.AuthTelegramRes, error) {
+	if h.telegramBotToken == "" {
+		return &baldaapi.AuthTelegramServiceUnavailable{
+			Status:  baldaapi.NewOptInt(http.StatusServiceUnavailable),
+			Message: baldaapi.NewOptString("telegram auth is not configured"),
+			Type:    baldaapi.NewOptString("ServiceUnavailable"),
+		}, nil
+	}
+
+	tgUser, err := auth.ValidateInitData(req.InitData, h.telegramBotToken, telegramInitDataMaxAge)
+	if err != nil {
+		return &baldaapi.AuthTelegramUnauthorized{
+			Status:  baldaapi.NewOptInt(http.StatusUnauthorized),
+			Message: baldaapi.NewOptString("invalid telegram init data"),
+			Type:    baldaapi.NewOptString("Unauthorized"),
+		}, nil
+	}
+
+	u, err := h.svc.GetUserByTelegramID(ctx, tgUser.ID)
+	if err != nil {
+		if !errors.Is(err, storage.ErrInvalidCredentials) {
+			slog.Error("auth telegram: get user", slog.Any("error", err))
+			return authTelegramInternalError(), nil
+		}
+
+		// First visit: register the user linked to their Telegram account.
+		nickname := tgUser.Username
+		if nickname == "" {
+			nickname = flname.GenNickname()
+		}
+		created, err := h.svc.CreateTelegramUser(ctx, tgUser.FirstName, tgUser.LastName, nickname, tgUser.ID)
+		if err != nil {
+			slog.Error("auth telegram: create user", slog.Any("error", err))
+			return authTelegramInternalError(), nil
+		}
+		slog.Info("auth telegram: registered new user", slog.Int64("telegram_id", tgUser.ID))
+		u = storage.UserAuth{
+			UID:       created.UID,
+			Firstname: tgUser.FirstName,
+			Lastname:  tgUser.LastName,
+			PlayerID:  created.PlayerID,
+			Rating:    created.Rating,
+			Role:      created.Role,
+		}
+	}
+
+	resp, errResp := h.newAuthResponse(ctx, u)
+	if errResp != nil {
+		return authTelegramInternalError(), nil
+	}
+	return resp, nil
+}
+
+// authTelegramInternalError maps the shared response builder's generic error
+// to this operation's typed 500.
+func authTelegramInternalError() *baldaapi.AuthTelegramInternalServerError {
+	return &baldaapi.AuthTelegramInternalServerError{
+		Status:  baldaapi.NewOptInt(http.StatusInternalServerError),
+		Message: baldaapi.NewOptString("internal error"),
+		Type:    baldaapi.NewOptString("InternalServerError"),
+	}
+}

--- a/internal/server/restapi/handlers/handlers.go
+++ b/internal/server/restapi/handlers/handlers.go
@@ -23,10 +23,11 @@ type Handlers struct {
 	cf                        *centrifugo.Client
 	centrifugoTokenHMACSecret string
 	emailSignupEnabled        bool
+	telegramBotToken          string
 }
 
-func New(svc *service.Balda, pres *presence.Service, jwtSecret string, cf *centrifugo.Client, centrifugoTokenHMACSecret string, emailSignupEnabled bool) *Handlers {
-	return &Handlers{svc: svc, pres: pres, jwtSecret: jwtSecret, cf: cf, centrifugoTokenHMACSecret: centrifugoTokenHMACSecret, emailSignupEnabled: emailSignupEnabled}
+func New(svc *service.Balda, pres *presence.Service, jwtSecret string, cf *centrifugo.Client, centrifugoTokenHMACSecret string, emailSignupEnabled bool, telegramBotToken string) *Handlers {
+	return &Handlers{svc: svc, pres: pres, jwtSecret: jwtSecret, cf: cf, centrifugoTokenHMACSecret: centrifugoTokenHMACSecret, emailSignupEnabled: emailSignupEnabled, telegramBotToken: telegramBotToken}
 }
 
 // uidFromContext returns the authenticated user's id from the JWT claims placed

--- a/internal/service/balda_service.go
+++ b/internal/service/balda_service.go
@@ -99,6 +99,16 @@ func (s *Balda) GetUserForToken(ctx context.Context, uid int64) (storage.UserFor
 	return s.s.GetUserForToken(ctx, uid)
 }
 
+// GetUserByTelegramID returns the user's identity for the given Telegram user ID.
+func (s *Balda) GetUserByTelegramID(ctx context.Context, telegramID int64) (storage.UserAuth, error) {
+	return s.s.GetUserByTelegramID(ctx, telegramID)
+}
+
+// CreateTelegramUser creates a new user registered via Telegram Mini App auth.
+func (s *Balda) CreateTelegramUser(ctx context.Context, firstname, lastname, nickname string, telegramID int64) (storage.UserCreated, error) {
+	return s.s.CreateTelegramUser(ctx, firstname, lastname, nickname, telegramID)
+}
+
 // SaveRefreshToken persists the HMAC hash of a refresh token for the user.
 func (s *Balda) SaveRefreshToken(ctx context.Context, uid int64, tokenHash string, expiresAt time.Time, userAgent, ipAddr string) error {
 	return s.s.SaveRefreshToken(ctx, uid, tokenHash, expiresAt, userAgent, ipAddr)

--- a/internal/storage/user.go
+++ b/internal/storage/user.go
@@ -86,6 +86,74 @@ func (b *Balda) GetUserForToken(ctx context.Context, uid int64) (UserForToken, e
 	return u, nil
 }
 
+// GetUserByTelegramID returns the user's identity for the given Telegram user ID.
+// Returns ErrInvalidCredentials when no user is linked to that Telegram account.
+func (b *Balda) GetUserByTelegramID(ctx context.Context, telegramID int64) (UserAuth, error) {
+	ctx, cancel := context.WithTimeout(ctx, b.t)
+	defer cancel()
+
+	var u UserAuth
+	err := b.db.QueryRow(ctx, `
+		SELECT u.user_id, u.first_name, u.last_name, ps.player_id, COALESCE(ps.exp, 0), COALESCE(ps.rating, $1), u.role
+		FROM users u
+		JOIN player_state ps ON ps.user_id = u.user_id
+		WHERE u.telegram_id = $2
+	`, DefaultRating, telegramID).Scan(&u.UID, &u.Firstname, &u.Lastname, &u.PlayerID, &u.Exp, &u.Rating, &u.Role)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return UserAuth{}, ErrInvalidCredentials
+	}
+	if err != nil {
+		return UserAuth{}, fmt.Errorf("get user by telegram id: %w", err)
+	}
+	return u, nil
+}
+
+// CreateTelegramUser inserts a new user registered via Telegram Mini App auth
+// together with their player_state in a single transaction. The user has no
+// email and no usable password: password login is unavailable for them.
+func (b *Balda) CreateTelegramUser(ctx context.Context, firstname, lastname, nickname string, telegramID int64) (UserCreated, error) {
+	ctx, cancel := context.WithTimeout(ctx, b.t)
+	defer cancel()
+
+	tx, err := b.db.Begin(ctx)
+	if err != nil {
+		return UserCreated{}, fmt.Errorf("create telegram user: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	// A random unguessable password hash: the account must not be loginable
+	// via email/password.
+	hash, err := bcrypt.GenerateFromPassword([]byte(uuid.NewString()), bcryptCost)
+	if err != nil {
+		return UserCreated{}, fmt.Errorf("create telegram user: hash password: %w", err)
+	}
+
+	var created UserCreated
+	err = tx.QueryRow(ctx,
+		`INSERT INTO users(first_name, last_name, email, hash_password, telegram_id, confirmed)
+		 VALUES($1, $2, NULL, $3, $4, true) RETURNING user_id, role`,
+		firstname, lastname, string(hash), telegramID,
+	).Scan(&created.UID, &created.Role)
+	if err != nil {
+		return UserCreated{}, fmt.Errorf("create telegram user: insert users: %w", err)
+	}
+
+	err = tx.QueryRow(ctx,
+		`INSERT INTO player_state(user_id, nickname, exp, rating, flags, lives, total_games, consecutive_wins)
+		 VALUES($1, $2, $3, $4, $5, $6, $7, $8) RETURNING player_id`,
+		created.UID, nickname, 0, DefaultRating, 0, 5, 0, 0,
+	).Scan(&created.PlayerID)
+	created.Rating = DefaultRating
+	if err != nil {
+		return UserCreated{}, fmt.Errorf("create telegram user: insert player_state: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return UserCreated{}, fmt.Errorf("create telegram user: commit: %w", err)
+	}
+	return created, nil
+}
+
 // CreateUser inserts a new user and their player_state in a single transaction.
 func (b *Balda) CreateUser(ctx context.Context, firstname, lastname, email, password, nickname string) (UserCreated, error) {
 	ctx, cancel := context.WithTimeout(ctx, b.t)

--- a/migrations/011_telegram_auth.up.sql
+++ b/migrations/011_telegram_auth.up.sql
@@ -1,0 +1,22 @@
+alter table users
+    add column if not exists telegram_id bigint;
+
+create unique index if not exists users_telegram_id_uindex
+    on users (telegram_id)
+    where telegram_id is not null;
+
+-- Telegram users have no email; allow NULL emails while keeping uniqueness
+-- for the ones that are set.
+drop index if exists users_email_uindex;
+create unique index users_email_uindex
+    on users (email)
+    where email is not null;
+
+---- create above / drop below ----
+
+drop index if exists users_email_uindex;
+create unique index users_email_uindex
+    on users (email);
+
+drop index if exists users_telegram_id_uindex;
+alter table users drop column if exists telegram_id;

--- a/tests/auth_telegram_test.go
+++ b/tests/auth_telegram_test.go
@@ -1,0 +1,126 @@
+package tests
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rustwizard/balda/internal/centrifugo"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+	"github.com/rustwizard/balda/internal/server/restapi/handlers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testTelegramBotToken = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+
+// buildTelegramInitData signs test init data with the test bot token,
+// mimicking what the Telegram WebView produces.
+func buildTelegramInitData(t *testing.T, fields map[string]string) string {
+	t.Helper()
+
+	pairs := make([]string, 0, len(fields))
+	for k, v := range fields {
+		pairs = append(pairs, k+"="+v)
+	}
+	sort.Strings(pairs)
+	dataCheckString := strings.Join(pairs, "\n")
+
+	secretMAC := hmac.New(sha256.New, []byte("WebAppData"))
+	secretMAC.Write([]byte(testTelegramBotToken))
+	sigMAC := hmac.New(sha256.New, secretMAC.Sum(nil))
+	sigMAC.Write([]byte(dataCheckString))
+
+	q := url.Values{}
+	for k, v := range fields {
+		q.Set(k, v)
+	}
+	q.Set("hash", hex.EncodeToString(sigMAC.Sum(nil)))
+	return q.Encode()
+}
+
+func telegramUserFields(tgID int64) map[string]string {
+	return map[string]string{
+		"auth_date": strconv.FormatInt(time.Now().Unix(), 10),
+		"query_id":  "AAHdF6IQAAAAAN0XohDhrOrc",
+		"user":      `{"id":` + strconv.FormatInt(tgID, 10) + `,"first_name":"Tema","last_name":"Testov","username":"tema_test"}`,
+	}
+}
+
+func setupTelegramHandlers(t *testing.T) (*handlers.Handlers, func()) {
+	t.Helper()
+	ctx := context.Background()
+	core := setupCore(ctx, t)
+	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, testTelegramBotToken)
+	return h, core.cleanup
+}
+
+func TestAuthTelegram(t *testing.T) {
+	h, cleanup := setupTelegramHandlers(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const tgID = int64(279058397)
+	initData := buildTelegramInitData(t, telegramUserFields(tgID))
+
+	t.Run("first visit registers the user", func(t *testing.T) {
+		res, err := h.AuthTelegram(ctx, &baldaapi.TelegramAuthRequest{InitData: initData})
+		require.NoError(t, err)
+
+		ok, isOK := res.(*baldaapi.AuthResponse)
+		require.True(t, isOK, "expected *AuthResponse, got %T", res)
+		require.True(t, ok.Player.IsSet())
+		assert.Equal(t, "Tema", ok.Player.Value.Firstname.Value)
+		assert.Equal(t, "Testov", ok.Player.Value.Lastname.Value)
+		assert.NotEmpty(t, ok.AccessToken.Value)
+		assert.NotEmpty(t, ok.RefreshToken.Value)
+	})
+
+	t.Run("second visit logs into the same account", func(t *testing.T) {
+		var firstUID string
+		res, err := h.AuthTelegram(ctx, &baldaapi.TelegramAuthRequest{InitData: initData})
+		require.NoError(t, err)
+		first := res.(*baldaapi.AuthResponse) //nolint:errcheck
+		firstUID = first.Player.Value.UID.Value.String()
+
+		res, err = h.AuthTelegram(ctx, &baldaapi.TelegramAuthRequest{InitData: initData})
+		require.NoError(t, err)
+		second := res.(*baldaapi.AuthResponse) //nolint:errcheck
+		assert.Equal(t, firstUID, second.Player.Value.UID.Value.String(), "must not create a duplicate user")
+	})
+
+	t.Run("tampered init data is rejected", func(t *testing.T) {
+		tampered := strings.Replace(initData, "Tema", "Mallory", 1)
+		require.NotEqual(t, initData, tampered)
+
+		res, err := h.AuthTelegram(ctx, &baldaapi.TelegramAuthRequest{InitData: tampered})
+		require.NoError(t, err)
+
+		unauthorized, isUnauthorized := res.(*baldaapi.AuthTelegramUnauthorized)
+		require.True(t, isUnauthorized, "expected *AuthTelegramUnauthorized, got %T", res)
+		assert.Equal(t, 401, unauthorized.Status.Value)
+	})
+}
+
+func TestAuthTelegram_NotConfigured(t *testing.T) {
+	ctx := context.Background()
+	core := setupCore(ctx, t)
+	defer core.cleanup()
+	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, "")
+
+	res, err := h.AuthTelegram(ctx, &baldaapi.TelegramAuthRequest{InitData: "whatever=1"})
+	require.NoError(t, err)
+
+	unavailable, isUnavailable := res.(*baldaapi.AuthTelegramServiceUnavailable)
+	require.True(t, isUnavailable, "expected *AuthTelegramServiceUnavailable, got %T", res)
+	assert.Equal(t, 503, unavailable.Status.Value)
+}

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -68,7 +68,7 @@ func setupHandlersWithCentrifugo(ctx context.Context, t *testing.T, cfAPIURL str
 	t.Helper()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient(cfAPIURL, testCentrifugoAPIKey)
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, testCentrifugoSecret, true)
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, testCentrifugoSecret, true, "")
 	return h, core.cleanup
 }
 

--- a/tests/handlers_test.go
+++ b/tests/handlers_test.go
@@ -154,7 +154,7 @@ func setupHandlers(t *testing.T) (*handlers.Handlers, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true)
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "")
 	return h, core.cleanup
 }
 
@@ -163,7 +163,7 @@ func TestSignupDisabled(t *testing.T) {
 	core := setupCore(ctx, t)
 	defer core.cleanup()
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false)
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, "")
 
 	res, err := h.Signup(ctx, &baldaapi.SignupRequest{
 		Firstname: "No",
@@ -485,7 +485,7 @@ func setupFull(t *testing.T) (*handlers.Handlers, *lobby.Lobby, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true)
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "")
 	return h, core.lby, core.cleanup
 }
 

--- a/tests/leaderboard_test.go
+++ b/tests/leaderboard_test.go
@@ -23,7 +23,7 @@ func setupLeaderboard(t *testing.T) (*handlers.Handlers, *storage.Balda, *redis.
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true)
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "")
 	return h, core.s, core.rdb, core.cleanup
 }
 


### PR DESCRIPTION
- POST /auth/telegram: validates signed init data against the bot token (HMAC per Telegram docs, 24h auth_date freshness), then logs in or creates a user linked by telegram_id; issues the same JWT pair, centrifugo tokens and active-game snapshot as /auth
- migration 011: users.telegram_id + partial unique indexes (telegram_id, email) so Telegram users need no email/password
- TELEGRAM_BOT_TOKEN config (optional; endpoint answers 503 when unset)
- frontend: auto-login inside the Telegram WebView (no form), shared auth-response handling with the email flow
- docs/deployment.md: BotFather setup steps