### PR TITLE
feat: filter dictionary to classic balda vocabulary

### DIFF
--- a/internal/game/dictionary.go
+++ b/internal/game/dictionary.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -33,6 +35,8 @@ func NewDictionary() (*Dictionary, error) {
 	}
 	defer f.Close() //nolint:errcheck
 
+	raw := make(map[string]string, 56000)
+
 	dec := json.NewDecoder(f)
 	for {
 		var words map[string]interface{}
@@ -54,16 +58,80 @@ func NewDictionary() (*Dictionary, error) {
 			}
 
 			def := v.(map[string]interface{})
-			normK := normalizeWord(k)
-			dict.Definition[normK] = def["definition"].(string)
-
-			if utf8.RuneCountInString(normK) == 5 {
-				dict.FiveLetters = append(dict.FiveLetters, normK)
-			}
+			raw[normalizeWord(k)] = def["definition"].(string)
 		}
 	}
 
+	// Filter out entries that break the classic Balda rules or feel unfair
+	// to casual players (the bot plays by this dictionary too).
+	var droppedArchaic, droppedPluralAlias int
+	for w, def := range raw {
+		if isArchaic(def) {
+			droppedArchaic++
+			continue
+		}
+		if isPluralAlias(w, def, raw) {
+			droppedPluralAlias++
+			continue
+		}
+		dict.Definition[w] = def
+		if utf8.RuneCountInString(w) == 5 {
+			dict.FiveLetters = append(dict.FiveLetters, w)
+		}
+	}
+	slog.Info("game: dictionary loaded",
+		slog.Int("kept", len(dict.Definition)),
+		slog.Int("dropped_archaic", droppedArchaic),
+		slog.Int("dropped_plural_alias", droppedPluralAlias),
+	)
+
 	return dict, nil
+}
+
+// isArchaic reports whether the dictionary entry is marked obsolete (устар.).
+func isArchaic(def string) bool {
+	return strings.Contains(def, "устар.")
+}
+
+// isPluralAlias reports whether the entry is a plural form that merely
+// aliases another word ("мн. ... То же, что: ...") while its singular form
+// exists in the dictionary. Classic Balda allows singular nouns (plus
+// pluralia tantum), so such aliases are excluded. Plurals with their own
+// distinct meaning (руки "рабочая сила", коты "тёплая обувь") are kept,
+// because they are not cross-references.
+func isPluralAlias(word, def string, dict map[string]string) bool {
+	if !strings.HasPrefix(def, "мн.") {
+		return false
+	}
+	if !strings.Contains(strings.ToLower(def), "то же, что") {
+		return false
+	}
+	for _, c := range singularCandidates(word) {
+		if _, ok := dict[c]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// singularCandidates returns plausible singular forms of a plural word.
+func singularCandidates(w string) []string {
+	r := []rune(w)
+	if len(r) < 2 {
+		return nil
+	}
+	stem := string(r[:len(r)-1])
+	switch {
+	case strings.HasSuffix(w, "йцы") && len(r) >= 3: // нанайцы -> нанаец
+		return []string{string(r[:len(r)-3]) + "ец", stem}
+	case strings.HasSuffix(w, "цы"): // немцы -> немец
+		return []string{string(r[:len(r)-2]) + "ец", stem}
+	case strings.HasSuffix(w, "ы"), strings.HasSuffix(w, "и"): // гольды -> гольд
+		return []string{stem, stem + "ь", stem + "й"}
+	case strings.HasSuffix(w, "а"): // дома -> дом
+		return []string{stem, stem + "о"}
+	}
+	return nil
 }
 
 func (d *Dictionary) RandomFiveLetterWord() string {

--- a/internal/game/dictionary_filter_test.go
+++ b/internal/game/dictionary_filter_test.go
@@ -1,0 +1,52 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsArchaic(t *testing.T) {
+	assert.True(t, isArchaic("м. устар. То же, что: нанаец."))
+	assert.True(t, isArchaic("ж. устар. редк. Старинная обувь."))
+	assert.False(t, isArchaic("м. 1) Жилое здание."))
+	assert.False(t, isArchaic("мн. Верхняя одежда."))
+}
+
+func TestIsPluralAlias(t *testing.T) {
+	dict := map[string]string{
+		"гольд":   "м. устар. То же, что: нанаец.",
+		"нанаец":  "м. Житель Приамурья.",
+		"ножница": "ж. устар. редк. То же, что: ножки (для мебели).",
+		"кот":     "м. Домашнее животное.",
+		"рука":    "ж. Конечность человека.",
+		"дом":     "м. Жилое здание.",
+	}
+
+	cases := []struct {
+		name string
+		word string
+		def  string
+		want bool
+	}{
+		{"plural alias with singular in dict", "гольды", "мн. устар. То же, что: нанайцы.", true},
+		{"singular entry", "дом", "м. Жилое здание.", false},
+		{"plural with own meaning (работники)", "руки", "мн. разг. 1) Рабочая сила.", false},
+		{"plural homograph with own meaning (обувь)", "коты", "мн. местн. Теплая, преимущественно женская обувь.", false},
+		{"pluralia tantum, no cross-reference", "ножницы", "1. мн. 1) Инструмент для резки.", false},
+		{"cross-ref but no singular in dict", "плесы", "мн. То же, что: глубоководные участки.", false},
+		{"not a plural entry", "кот", "м. Домашнее животное.", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPluralAlias(tc.word, tc.def, dict))
+		})
+	}
+}
+
+func TestSingularCandidates(t *testing.T) {
+	assert.Equal(t, []string{"нанаец", "нанайц"}, singularCandidates("нанайцы"))
+	assert.Equal(t, []string{"гольд", "гольдь", "гольдй"}, singularCandidates("гольды"))
+	assert.Equal(t, []string{"дом", "домо"}, singularCandidates("дома"))
+	assert.Nil(t, singularCandidates("я"))
+}


### PR DESCRIPTION
- drop entries marked устар. (obsolete) — ~5k words casual players and the bot should not be playing (гольд, гольды и ко)
- drop plural aliases ("мн." entries that cross-reference another word while their singular exists in the dictionary) — plurals are against classic rules; pluralia tantum (ножницы) and plurals with distinct meanings (руки, коты) are kept
- log kept/dropped counts at dictionary load