### PR TITLE
fix: leave waiting game endpoint, SPA cache headers

### DIFF
--- a/api/openapi/http-api.yaml
+++ b/api/openapi/http-api.yaml
@@ -611,6 +611,46 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /games/{id}/leave:
+    post:
+      operationId: leaveGame
+      summary: Leave a waiting game
+      description: |
+        Removes the player from a game in waiting status. If the game
+        becomes empty, it is deleted. In-progress games cannot be left
+        this way.
+      tags:
+        - Games
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the game
+      responses:
+        "204":
+          description: Left the game successfully
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Game not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Game is not in waiting status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /player/achievements:
     get:
       operationId: getPlayerAchievements

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -34,6 +34,16 @@ server {
 
     # SPA fallback
     location / {
+        # The HTML shell must always be revalidated: it references hashed
+        # bundles, so a stale index.html pins clients (and the Telegram
+        # WebView) to an old build.
+        add_header Cache-Control "no-cache" always;
         try_files $uri $uri/ /index.html;
+    }
+
+    # Hashed build artifacts are immutable — the filename changes every build.
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
     }
 }

--- a/frontend/src/components/Lobby.svelte
+++ b/frontend/src/components/Lobby.svelte
@@ -51,7 +51,13 @@
       if (res.game_token) {
         centrifugo.subscribe(`game:${res.game.id}`, res.game_token);
       }
-      gameState.startGame(res.game);
+      // A freshly created game is waiting for an opponent — show the
+      // waiting screen (with a working cancel), not the game board.
+      if (res.game.status === 'waiting') {
+        gameState.setWaiting(res.game);
+      } else {
+        gameState.startGame(res.game);
+      }
     } catch (err: any) {
       error = err.message;
     } finally {

--- a/frontend/src/components/WaitingScreen.svelte
+++ b/frontend/src/components/WaitingScreen.svelte
@@ -1,5 +1,20 @@
 <script lang="ts">
   import { gameState } from '../stores/game.svelte';
+  import { leaveGame } from '../lib/api';
+
+  let error = $state('');
+
+  async function cancel() {
+    error = '';
+    const gameId = gameState.game?.id;
+    try {
+      if (gameId) await leaveGame(gameId);
+    } catch (e: any) {
+      error = e?.message || 'Не удалось отменить игру';
+      return;
+    }
+    gameState.setLobby();
+  }
 </script>
 
 <div class="mx-auto flex w-full max-w-md flex-col items-center rounded-2xl bg-white p-8 shadow-lg">
@@ -9,8 +24,11 @@
     Игра создана. Поделитесь ID игры с другом:<br />
     <span class="mt-1 inline-block rounded-lg bg-stone-100 px-3 py-1 font-mono text-sm text-stone-700">{gameState.game?.id}</span>
   </p>
+  {#if error}
+    <div class="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>
+  {/if}
   <button
-    onclick={() => gameState.setLobby()}
+    onclick={cancel}
     class="mt-6 rounded-xl bg-stone-200 px-6 py-2 font-bold text-stone-700 transition hover:bg-stone-300"
   >
     Отменить

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -161,6 +161,10 @@ export function joinGame(gameId: string): Promise<JoinGameResponse> {
   return apiFetch(`/games/${gameId}/join`, { method: 'POST' });
 }
 
+export function leaveGame(gameId: string): Promise<void> {
+  return apiFetch(`/games/${gameId}/leave`, { method: 'POST' });
+}
+
 export function submitMove(gameId: string, payload: MoveRequest): Promise<MoveResponse> {
   return apiFetch(`/games/${gameId}/move`, { method: 'POST', body: JSON.stringify(payload) });
 }

--- a/internal/lobby/lobby.go
+++ b/internal/lobby/lobby.go
@@ -16,6 +16,7 @@ var (
 	ErrPlayerInGame   = errors.New("lobby: player already in a game")
 	ErrGameNotWaiting = errors.New("lobby: game is not in waiting status")
 	ErrGameFull       = errors.New("lobby: game already has enough players")
+	ErrNotParticipant = errors.New("lobby: player is not a participant of this game")
 )
 
 type GameStatus string
@@ -224,6 +225,39 @@ func (l *Lobby) StartGame(ctx context.Context, players []*game.Player, n game.No
 	}()
 
 	return rec, nil
+}
+
+// Leave removes the player from a waiting game. If the game becomes empty,
+// it is removed entirely. Only waiting games can be left this way — leaving
+// an in-progress game is a forfeit, which is a separate mechanic.
+func (l *Lobby) Leave(gameID, playerID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	rec, ok := l.games[gameID]
+	if !ok {
+		return ErrGameNotFound
+	}
+	if rec.Status != GameStatusWaiting {
+		return ErrGameNotWaiting
+	}
+	idx := -1
+	for i, p := range rec.Players {
+		if p.ID == playerID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return ErrNotParticipant
+	}
+
+	delete(l.byPlayer, playerID)
+	rec.Players = append(rec.Players[:idx], rec.Players[idx+1:]...)
+	if len(rec.Players) == 0 {
+		delete(l.games, rec.ID)
+	}
+	return nil
 }
 
 // Remove stops and deregisters a game by its ID.

--- a/internal/lobby/lobby_test.go
+++ b/internal/lobby/lobby_test.go
@@ -205,3 +205,47 @@ func TestLobby_ConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestLobby_Leave covers leaving a waiting game: participant removal, game
+// removal when it becomes empty, and error cases.
+func TestLobby_Leave(t *testing.T) {
+	t.Run("creator leaves, empty game is removed", func(t *testing.T) {
+		l := newLobby()
+		rec, err := l.Create(makePlayers("p1")[0])
+		require.NoError(t, err)
+
+		require.NoError(t, l.Leave(rec.ID, "p1"))
+		assert.Empty(t, l.List())
+		assert.ErrorIs(t, l.Leave(rec.ID, "p1"), lobby.ErrGameNotFound)
+	})
+
+	t.Run("second player cannot leave (only waiting games)", func(t *testing.T) {
+		l := newLobby()
+		rec, err := l.Create(makePlayers("p1")[0])
+		require.NoError(t, err)
+
+		_, err = l.Join(context.Background(), rec.ID, makePlayers("p2")[0], &game.NoopNotifier{})
+		require.NoError(t, err)
+
+		assert.ErrorIs(t, l.Leave(rec.ID, "p2"), lobby.ErrGameNotWaiting)
+	})
+
+	t.Run("non-participant gets ErrNotParticipant", func(t *testing.T) {
+		l := newLobby()
+		rec, err := l.Create(makePlayers("p1")[0])
+		require.NoError(t, err)
+
+		assert.ErrorIs(t, l.Leave(rec.ID, "ghost"), lobby.ErrNotParticipant)
+	})
+
+	t.Run("after leaving the player can create a new game", func(t *testing.T) {
+		l := newLobby()
+		rec, err := l.Create(makePlayers("p1")[0])
+		require.NoError(t, err)
+
+		require.NoError(t, l.Leave(rec.ID, "p1"))
+
+		_, err = l.Create(makePlayers("p1")[0])
+		assert.NoError(t, err)
+	})
+}

--- a/internal/server/ogen/oas_client_gen.go
+++ b/internal/server/ogen/oas_client_gen.go
@@ -104,6 +104,13 @@ type Invoker interface {
 	//
 	// POST /games/{id}/join
 	JoinGame(ctx context.Context, params JoinGameParams) (JoinGameRes, error)
+	// LeaveGame invokes leaveGame operation.
+	//
+	// Removes the player from a game in waiting status. If the game becomes empty, it is deleted.
+	// In-progress games cannot be left this way.
+	//
+	// POST /games/{id}/leave
+	LeaveGame(ctx context.Context, params LeaveGameParams) (LeaveGameRes, error)
 	// ListGames invokes listGames operation.
 	//
 	// Returns a snapshot of all currently active games.
@@ -1445,6 +1452,139 @@ func (c *Client) sendJoinGame(ctx context.Context, params JoinGameParams) (res J
 
 	stage = "DecodeResponse"
 	result, err := decodeJoinGameResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// LeaveGame invokes leaveGame operation.
+//
+// Removes the player from a game in waiting status. If the game becomes empty, it is deleted.
+// In-progress games cannot be left this way.
+//
+// POST /games/{id}/leave
+func (c *Client) LeaveGame(ctx context.Context, params LeaveGameParams) (LeaveGameRes, error) {
+	res, err := c.sendLeaveGame(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendLeaveGame(ctx context.Context, params LeaveGameParams) (res LeaveGameRes, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("leaveGame"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.URLTemplateKey.String("/games/{id}/leave"),
+	}
+	otelAttrs = append(otelAttrs, c.cfg.Attributes...)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, LeaveGameOperation,
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [3]string
+	pathParts[0] = "/games/"
+	{
+		// Encode "id" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "id",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.UUIDToString(params.ID))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/leave"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "POST", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			stage = "Security:BearerAuth"
+			switch err := c.securityBearerAuth(ctx, LeaveGameOperation, r); {
+			case err == nil: // if NO error
+				satisfied[0] |= 1 << 0
+			case errors.Is(err, ogenerrors.ErrSkipClientSecurity):
+				// Skip this security.
+			default:
+				return res, errors.Wrap(err, "security \"BearerAuth\"")
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			return res, ogenerrors.ErrSecurityRequirementIsNotSatisfied
+		}
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	body := resp.Body
+	defer func() {
+		// Drain the body to EOF before closing, so the underlying
+		// connection can be reused by the Transport regardless of the
+		// response status code. See https://github.com/ogen-go/ogen/issues/1670.
+		_, _ = io.Copy(io.Discard, body)
+		_ = body.Close()
+	}()
+
+	stage = "DecodeResponse"
+	result, err := decodeLeaveGameResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/internal/server/ogen/oas_handlers_gen.go
+++ b/internal/server/ogen/oas_handlers_gen.go
@@ -1852,6 +1852,194 @@ func (s *Server) handleJoinGameRequest(args [1]string, argsEscaped bool, w http.
 	}
 }
 
+// handleLeaveGameRequest handles leaveGame operation.
+//
+// Removes the player from a game in waiting status. If the game becomes empty, it is deleted.
+// In-progress games cannot be left this way.
+//
+// POST /games/{id}/leave
+func (s *Server) handleLeaveGameRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("leaveGame"),
+		semconv.HTTPRequestMethodKey.String("POST"),
+		semconv.HTTPRouteKey.String("/games/{id}/leave"),
+	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), LeaveGameOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(attrs...)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code < 100 || code >= 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: LeaveGameOperation,
+			ID:   "leaveGame",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securityBearerAuth(ctx, LeaveGameOperation, r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "BearerAuth",
+					Err:              err,
+				}
+				defer recordError("Security:BearerAuth", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodeLeaveGameParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var rawBody []byte
+
+	var response LeaveGameRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    LeaveGameOperation,
+			OperationSummary: "Leave a waiting game",
+			OperationID:      "leaveGame",
+			Body:             nil,
+			RawBody:          rawBody,
+			Params: middleware.Parameters{
+				{
+					Name: "id",
+					In:   "path",
+				}: params.ID,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = LeaveGameParams
+			Response = LeaveGameRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackLeaveGameParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.LeaveGame(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.LeaveGame(ctx, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodeLeaveGameResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleListGamesRequest handles listGames operation.
 //
 // Returns a snapshot of all currently active games.

--- a/internal/server/ogen/oas_interfaces_gen.go
+++ b/internal/server/ogen/oas_interfaces_gen.go
@@ -41,6 +41,10 @@ type JoinGameRes interface {
 	joinGameRes()
 }
 
+type LeaveGameRes interface {
+	leaveGameRes()
+}
+
 type ListGamesRes interface {
 	listGamesRes()
 }

--- a/internal/server/ogen/oas_json_gen.go
+++ b/internal/server/ogen/oas_json_gen.go
@@ -2572,6 +2572,158 @@ func (s *LeaderboardResponseSort) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes LeaveGameConflict as json.
+func (s *LeaveGameConflict) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes LeaveGameConflict from json.
+func (s *LeaveGameConflict) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode LeaveGameConflict to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = LeaveGameConflict(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *LeaveGameConflict) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *LeaveGameConflict) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes LeaveGameForbidden as json.
+func (s *LeaveGameForbidden) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes LeaveGameForbidden from json.
+func (s *LeaveGameForbidden) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode LeaveGameForbidden to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = LeaveGameForbidden(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *LeaveGameForbidden) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *LeaveGameForbidden) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes LeaveGameNotFound as json.
+func (s *LeaveGameNotFound) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes LeaveGameNotFound from json.
+func (s *LeaveGameNotFound) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode LeaveGameNotFound to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = LeaveGameNotFound(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *LeaveGameNotFound) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *LeaveGameNotFound) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes LeaveGameUnauthorized as json.
+func (s *LeaveGameUnauthorized) Encode(e *jx.Encoder) {
+	unwrapped := (*ErrorResponse)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes LeaveGameUnauthorized from json.
+func (s *LeaveGameUnauthorized) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode LeaveGameUnauthorized to nil")
+	}
+	var unwrapped ErrorResponse
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = LeaveGameUnauthorized(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *LeaveGameUnauthorized) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *LeaveGameUnauthorized) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode implements json.Marshaler.
 func (s *ListGamesResponse) Encode(e *jx.Encoder) {
 	e.ObjStart()

--- a/internal/server/ogen/oas_operations_gen.go
+++ b/internal/server/ogen/oas_operations_gen.go
@@ -17,6 +17,7 @@ const (
 	GetPlayerStateUIDOperation     OperationName = "GetPlayerStateUID"
 	GetPlayerStatsOperation        OperationName = "GetPlayerStats"
 	JoinGameOperation              OperationName = "JoinGame"
+	LeaveGameOperation             OperationName = "LeaveGame"
 	ListGamesOperation             OperationName = "ListGames"
 	LogoutOperation                OperationName = "Logout"
 	MatchmakingJoinOperation       OperationName = "MatchmakingJoin"

--- a/internal/server/ogen/oas_parameters_gen.go
+++ b/internal/server/ogen/oas_parameters_gen.go
@@ -433,6 +433,72 @@ func decodeJoinGameParams(args [1]string, argsEscaped bool, r *http.Request) (pa
 	return params, nil
 }
 
+// LeaveGameParams is parameters of leaveGame operation.
+type LeaveGameParams struct {
+	// ID of the game.
+	ID uuid.UUID
+}
+
+func unpackLeaveGameParams(packed middleware.Parameters) (params LeaveGameParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "id",
+			In:   "path",
+		}
+		params.ID = packed[key].(uuid.UUID)
+	}
+	return params
+}
+
+func decodeLeaveGameParams(args [1]string, argsEscaped bool, r *http.Request) (params LeaveGameParams, _ error) {
+	// Decode path: id.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "id",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToUUID(val)
+				if err != nil {
+					return err
+				}
+
+				params.ID = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "id",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
 // MoveGameParams is parameters of moveGame operation.
 type MoveGameParams struct {
 	// ID of the game.

--- a/internal/server/ogen/oas_response_decoders_gen.go
+++ b/internal/server/ogen/oas_response_decoders_gen.go
@@ -1381,6 +1381,155 @@ func decodeJoinGameResponse(resp *http.Response) (res JoinGameRes, _ error) {
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
 
+func decodeLeaveGameResponse(resp *http.Response) (res LeaveGameRes, _ error) {
+	switch resp.StatusCode {
+	case 204:
+		// Code 204.
+		return &LeaveGameNoContent{}, nil
+	case 401:
+		// Code 401.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response LeaveGameUnauthorized
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 403:
+		// Code 403.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response LeaveGameForbidden
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response LeaveGameNotFound
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 409:
+		// Code 409.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response LeaveGameConflict
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCodeWithResponse(resp)
+}
+
 func decodeListGamesResponse(resp *http.Response) (res ListGamesRes, _ error) {
 	switch resp.StatusCode {
 	case 200:

--- a/internal/server/ogen/oas_response_encoders_gen.go
+++ b/internal/server/ogen/oas_response_encoders_gen.go
@@ -516,6 +516,66 @@ func encodeJoinGameResponse(response JoinGameRes, w http.ResponseWriter, span tr
 	}
 }
 
+func encodeLeaveGameResponse(response LeaveGameRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *LeaveGameNoContent:
+		w.WriteHeader(204)
+
+		return nil
+
+	case *LeaveGameUnauthorized:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(401)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *LeaveGameForbidden:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(403)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *LeaveGameNotFound:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *LeaveGameConflict:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(409)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodeListGamesResponse(response ListGamesRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *ListGamesResponse:

--- a/internal/server/ogen/oas_router_gen.go
+++ b/internal/server/ogen/oas_router_gen.go
@@ -14,10 +14,10 @@ var (
 	rn5AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
-	rn20AllowedHeaders = map[string]string{
+	rn21AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type",
 	}
-	rn27AllowedHeaders = map[string]string{
+	rn28AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
 	rn6AllowedHeaders = map[string]string{
@@ -36,22 +36,25 @@ var (
 	rn18AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn24AllowedHeaders = map[string]string{
+	rn19AllowedHeaders = map[string]string{
+		"POST": "Authorization",
+	}
+	rn25AllowedHeaders = map[string]string{
 		"POST": "Authorization,Content-Type",
 	}
-	rn26AllowedHeaders = map[string]string{
+	rn27AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn28AllowedHeaders = map[string]string{
+	rn29AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn31AllowedHeaders = map[string]string{
+	rn32AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn21AllowedHeaders = map[string]string{
+	rn22AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
-	rn23AllowedHeaders = map[string]string{
+	rn24AllowedHeaders = map[string]string{
 		"POST": "Authorization",
 	}
 	rn11AllowedHeaders = map[string]string{
@@ -63,10 +66,10 @@ var (
 	rn16AllowedHeaders = map[string]string{
 		"GET": "Authorization",
 	}
-	rn25AllowedHeaders = map[string]string{
+	rn26AllowedHeaders = map[string]string{
 		"POST": "Authorization,X-Request-Id",
 	}
-	rn30AllowedHeaders = map[string]string{
+	rn31AllowedHeaders = map[string]string{
 		"POST": "Content-Type",
 	}
 )
@@ -174,7 +177,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn20AllowedHeaders,
+									allowedHeaders: rn21AllowedHeaders,
 									acceptPost:     "application/json",
 									acceptPatch:    "",
 								})
@@ -199,7 +202,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 							default:
 								s.notAllowed(w, r, notAllowedParams{
 									allowedMethods: "POST",
-									allowedHeaders: rn27AllowedHeaders,
+									allowedHeaders: rn28AllowedHeaders,
 									acceptPost:     "application/json",
 									acceptPatch:    "",
 								})
@@ -406,6 +409,33 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 
+						case 'l': // Prefix: "leave"
+
+							if l := len("leave"); len(elem) >= l && elem[0:l] == "leave" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch r.Method {
+								case "POST":
+									s.handleLeaveGameRequest([1]string{
+										args[0],
+									}, elemIsEscaped, w, r)
+								default:
+									s.notAllowed(w, r, notAllowedParams{
+										allowedMethods: "POST",
+										allowedHeaders: rn19AllowedHeaders,
+										acceptPost:     "",
+										acceptPatch:    "",
+									})
+								}
+
+								return
+							}
+
 						case 'm': // Prefix: "move"
 
 							if l := len("move"); len(elem) >= l && elem[0:l] == "move" {
@@ -424,7 +454,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn24AllowedHeaders,
+										allowedHeaders: rn25AllowedHeaders,
 										acceptPost:     "application/json",
 										acceptPatch:    "",
 									})
@@ -451,7 +481,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn26AllowedHeaders,
+										allowedHeaders: rn27AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -478,7 +508,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn28AllowedHeaders,
+										allowedHeaders: rn29AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -505,7 +535,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								default:
 									s.notAllowed(w, r, notAllowedParams{
 										allowedMethods: "POST",
-										allowedHeaders: rn31AllowedHeaders,
+										allowedHeaders: rn32AllowedHeaders,
 										acceptPost:     "",
 										acceptPatch:    "",
 									})
@@ -573,7 +603,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn21AllowedHeaders,
+								allowedHeaders: rn22AllowedHeaders,
 								acceptPost:     "",
 								acceptPatch:    "",
 							})
@@ -598,7 +628,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn23AllowedHeaders,
+								allowedHeaders: rn24AllowedHeaders,
 								acceptPost:     "",
 								acceptPatch:    "",
 							})
@@ -751,7 +781,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn25AllowedHeaders,
+								allowedHeaders: rn26AllowedHeaders,
 								acceptPost:     "",
 								acceptPatch:    "",
 							})
@@ -776,7 +806,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						default:
 							s.notAllowed(w, r, notAllowedParams{
 								allowedMethods: "POST",
-								allowedHeaders: rn30AllowedHeaders,
+								allowedHeaders: rn31AllowedHeaders,
 								acceptPost:     "application/json",
 								acceptPatch:    "",
 							})
@@ -1166,6 +1196,31 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 									r.operationID = "joinGame"
 									r.operationGroup = ""
 									r.pathPattern = "/games/{id}/join"
+									r.args = args
+									r.count = 1
+									return r, true
+								default:
+									return
+								}
+							}
+
+						case 'l': // Prefix: "leave"
+
+							if l := len("leave"); len(elem) >= l && elem[0:l] == "leave" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch method {
+								case "POST":
+									r.name = LeaveGameOperation
+									r.summary = "Leave a waiting game"
+									r.operationID = "leaveGame"
+									r.operationGroup = ""
+									r.pathPattern = "/games/{id}/leave"
 									r.args = args
 									r.count = 1
 									return r, true

--- a/internal/server/ogen/oas_schemas_gen.go
+++ b/internal/server/ogen/oas_schemas_gen.go
@@ -1048,6 +1048,27 @@ func (s *LeaderboardResponseSort) UnmarshalText(data []byte) error {
 	}
 }
 
+type LeaveGameConflict ErrorResponse
+
+func (*LeaveGameConflict) leaveGameRes() {}
+
+type LeaveGameForbidden ErrorResponse
+
+func (*LeaveGameForbidden) leaveGameRes() {}
+
+// LeaveGameNoContent is response for LeaveGame operation.
+type LeaveGameNoContent struct{}
+
+func (*LeaveGameNoContent) leaveGameRes() {}
+
+type LeaveGameNotFound ErrorResponse
+
+func (*LeaveGameNotFound) leaveGameRes() {}
+
+type LeaveGameUnauthorized ErrorResponse
+
+func (*LeaveGameUnauthorized) leaveGameRes() {}
+
 // Ref: #/components/schemas/ListGamesResponse
 type ListGamesResponse struct {
 	Games []GameSummary `json:"games"`

--- a/internal/server/ogen/oas_security_gen.go
+++ b/internal/server/ogen/oas_security_gen.go
@@ -41,6 +41,7 @@ var operationRolesBearerAuth = map[string][]string{
 	GetPlayerStateUIDOperation:     []string{},
 	GetPlayerStatsOperation:        []string{},
 	JoinGameOperation:              []string{},
+	LeaveGameOperation:             []string{},
 	ListGamesOperation:             []string{},
 	LogoutOperation:                []string{},
 	MatchmakingJoinOperation:       []string{},

--- a/internal/server/ogen/oas_server_gen.go
+++ b/internal/server/ogen/oas_server_gen.go
@@ -83,6 +83,13 @@ type Handler interface {
 	//
 	// POST /games/{id}/join
 	JoinGame(ctx context.Context, params JoinGameParams) (JoinGameRes, error)
+	// LeaveGame implements leaveGame operation.
+	//
+	// Removes the player from a game in waiting status. If the game becomes empty, it is deleted.
+	// In-progress games cannot be left this way.
+	//
+	// POST /games/{id}/leave
+	LeaveGame(ctx context.Context, params LeaveGameParams) (LeaveGameRes, error)
 	// ListGames implements listGames operation.
 	//
 	// Returns a snapshot of all currently active games.

--- a/internal/server/ogen/oas_unimplemented_gen.go
+++ b/internal/server/ogen/oas_unimplemented_gen.go
@@ -121,6 +121,16 @@ func (UnimplementedHandler) JoinGame(ctx context.Context, params JoinGameParams)
 	return r, ht.ErrNotImplemented
 }
 
+// LeaveGame implements leaveGame operation.
+//
+// Removes the player from a game in waiting status. If the game becomes empty, it is deleted.
+// In-progress games cannot be left this way.
+//
+// POST /games/{id}/leave
+func (UnimplementedHandler) LeaveGame(ctx context.Context, params LeaveGameParams) (r LeaveGameRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // ListGames implements listGames operation.
 //
 // Returns a snapshot of all currently active games.

--- a/internal/server/restapi/handlers/leave_game.go
+++ b/internal/server/restapi/handlers/leave_game.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/rustwizard/balda/internal/lobby"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+)
+
+// LeaveGame implements baldaapi.Handler.
+func (h *Handlers) LeaveGame(ctx context.Context, params baldaapi.LeaveGameParams) (baldaapi.LeaveGameRes, error) {
+	uid, ok := uidFromContext(ctx)
+	if !ok {
+		return &baldaapi.LeaveGameUnauthorized{
+			Status:  baldaapi.NewOptInt(http.StatusUnauthorized),
+			Message: baldaapi.NewOptString("unauthorized"),
+			Type:    baldaapi.NewOptString("Unauthorized"),
+		}, nil
+	}
+
+	err := h.svc.LeaveGame(ctx, uid, params.ID.String())
+	switch {
+	case err == nil:
+		h.publishLobbyUpdate(ctx)
+		return &baldaapi.LeaveGameNoContent{}, nil
+	case errors.Is(err, lobby.ErrGameNotFound):
+		return &baldaapi.LeaveGameNotFound{
+			Status:  baldaapi.NewOptInt(http.StatusNotFound),
+			Message: baldaapi.NewOptString("game not found"),
+			Type:    baldaapi.NewOptString("NotFound"),
+		}, nil
+	case errors.Is(err, lobby.ErrNotParticipant):
+		return &baldaapi.LeaveGameForbidden{
+			Status:  baldaapi.NewOptInt(http.StatusForbidden),
+			Message: baldaapi.NewOptString("not a participant of this game"),
+			Type:    baldaapi.NewOptString("Forbidden"),
+		}, nil
+	case errors.Is(err, lobby.ErrGameNotWaiting):
+		return &baldaapi.LeaveGameConflict{
+			Status:  baldaapi.NewOptInt(http.StatusConflict),
+			Message: baldaapi.NewOptString("game is not in waiting status"),
+			Type:    baldaapi.NewOptString("Conflict"),
+		}, nil
+	default:
+		slog.Error("leave_game: leave", slog.Any("error", err))
+		return nil, err
+	}
+}

--- a/internal/service/balda_service.go
+++ b/internal/service/balda_service.go
@@ -159,6 +159,16 @@ func (s *Balda) QuickMatchLeave(ctx context.Context, uid int64) error {
 	return nil
 }
 
+// LeaveGame removes the user from a waiting game, deleting the game
+// entirely when it becomes empty.
+func (s *Balda) LeaveGame(ctx context.Context, uid int64, gameID string) error {
+	pid, err := s.playerIDByUID(ctx, uid)
+	if err != nil {
+		return err
+	}
+	return s.lby.Leave(gameID, pid)
+}
+
 // CreateGame creates a new game in waiting status for the given user.
 func (s *Balda) CreateGame(ctx context.Context, uid int64) (*lobby.GameRecord, error) {
 	p, err := s.s.GetPlayerByUID(ctx, uid)

--- a/tests/leave_game_test.go
+++ b/tests/leave_game_test.go
@@ -1,0 +1,64 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaveGame(t *testing.T) {
+	h, cleanup := setupHandlers(t)
+	defer cleanup()
+
+	createGame := func(ctx context.Context) uuid.UUID {
+		t.Helper()
+		res, err := h.CreateGame(ctx)
+		require.NoError(t, err)
+		created, ok := res.(*baldaapi.CreateGameResponse)
+		require.True(t, ok, "expected *CreateGameResponse, got %T", res)
+		return created.Game.Value.ID.Value
+	}
+
+	t.Run("leave waiting game and create again", func(t *testing.T) {
+		ctx, _ := signupCtx(t, h, "leave.creator@example.org")
+		gid := createGame(ctx)
+
+		res, err := h.LeaveGame(ctx, baldaapi.LeaveGameParams{ID: gid})
+		require.NoError(t, err)
+		_, isNoContent := res.(*baldaapi.LeaveGameNoContent)
+		require.True(t, isNoContent, "expected *LeaveGameNoContent, got %T", res)
+
+		// The player is free to create a new game right away.
+		_ = createGame(ctx)
+	})
+
+	t.Run("cannot leave an in-progress game", func(t *testing.T) {
+		ctx, _ := signupCtx(t, h, "leave.owner@example.org")
+		gid := createGame(ctx)
+
+		ctx2, _ := signupCtx(t, h, "leave.joiner@example.org")
+		_, err := h.JoinGame(ctx2, baldaapi.JoinGameParams{ID: gid})
+		require.NoError(t, err)
+
+		res, err := h.LeaveGame(ctx, baldaapi.LeaveGameParams{ID: gid})
+		require.NoError(t, err)
+		conflict, isConflict := res.(*baldaapi.LeaveGameConflict)
+		require.True(t, isConflict, "expected *LeaveGameConflict, got %T", res)
+		assert.Equal(t, 409, conflict.Status.Value)
+	})
+
+	t.Run("non-participant gets 403", func(t *testing.T) {
+		ctx, _ := signupCtx(t, h, "leave.host@example.org")
+		gid := createGame(ctx)
+
+		ctx3, _ := signupCtx(t, h, "leave.outsider@example.org")
+		res, err := h.LeaveGame(ctx3, baldaapi.LeaveGameParams{ID: gid})
+		require.NoError(t, err)
+		_, isForbidden := res.(*baldaapi.LeaveGameForbidden)
+		require.True(t, isForbidden, "expected *LeaveGameForbidden, got %T", res)
+	})
+}


### PR DESCRIPTION
- POST /games/{id}/leave: removes the player from a waiting game and deletes it when empty; lobby_update follows. Previously the cancel button only reset the client, leaving the player stuck in a game
- frontend: creating a private game shows the waiting screen (with a working cancel) instead of the board
- nginx: index.html served with no-cache, hashed /assets immutable, so clients (incl. the Telegram WebView) pick up new builds after deploy