### PR TITLE
fix: start bot game immediately when quick match queue is empty

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -224,15 +224,10 @@ var serverCmd = &cobra.Command{
 			}
 		}
 
-		mm := matchmaking.New(matchmaking.DefaultConfig(), func(players []*game.Player) error {
-			rec, err := lby.StartGame(context.Background(), players, &game.NoopNotifier{})
-			if err != nil {
-				return err
-			}
-			publishMatchFound(rec, players, false)
-			return nil
-		}).WithExpireCallback(func(p *game.Player) error {
-			// No human opponent showed up in time: fall back to a bot game.
+		// startBotGame falls back to a bot game when no human opponent is
+		// available. Used both by the matchmaking expire callback and
+		// synchronously by QuickMatchJoin when the queue is empty.
+		startBotGame := func(p *game.Player) error {
 			players := []*game.Player{p, {ID: bot.BotPlayerID, Rating: storage.DefaultRating, Type: game.PlayerTypeBot}}
 			rec, err := lby.StartGame(context.Background(), players, &game.NoopNotifier{})
 			if err != nil {
@@ -240,12 +235,20 @@ var serverCmd = &cobra.Command{
 			}
 			publishMatchFound(rec, players, true)
 			return nil
-		}).WithOnlineChecker(presenceChecker{pres}.IsOnline)
+		}
+		mm := matchmaking.New(matchmaking.DefaultConfig(), func(players []*game.Player) error {
+			rec, err := lby.StartGame(context.Background(), players, &game.NoopNotifier{})
+			if err != nil {
+				return err
+			}
+			publishMatchFound(rec, players, false)
+			return nil
+		}).WithExpireCallback(startBotGame).WithOnlineChecker(presenceChecker{pres}.IsOnline)
 		go mm.Run(cmd.Context())
 
 		lb := leaderboard.NewService(s, rdb, 5*time.Minute)
 
-		svc := service.New(lby, mm, s, lb, achSvc)
+		svc := service.New(lby, mm, s, lb, achSvc).WithBotFallback(startBotGame)
 
 		h := handlers.New(svc, pres, cfg.Auth.JWTSecret, cf, cfg.Centrifugo.TokenHMACSecret, cfg.Auth.EmailSignupEnabled, cfg.Telegram.BotToken)
 

--- a/frontend/src/components/Lobby.svelte
+++ b/frontend/src/components/Lobby.svelte
@@ -16,12 +16,16 @@
 
   async function quickMatch() {
     error = '';
+    // Set searching before the request: when nobody is queued the server
+    // starts a bot game immediately and match_found may arrive before the
+    // HTTP response, clearing the flag again.
+    gameState.setSearching(true);
+    searchSeconds = 0;
+    searchTimer = setInterval(() => (searchSeconds += 1), 1000);
     try {
       await joinMatchmaking();
-      gameState.setSearching(true);
-      searchSeconds = 0;
-      searchTimer = setInterval(() => (searchSeconds += 1), 1000);
     } catch (err: any) {
+      stopSearch();
       error = err.message;
     }
   }
@@ -144,7 +148,7 @@
   {#if gameState.searching}
     <div class="mb-4 rounded-xl bg-blue-50 p-4 text-center">
       <div class="mb-1 text-lg font-bold text-blue-800">Ищем соперника…</div>
-      <div class="mb-3 text-sm text-blue-600">{searchSeconds} сек — не найдём живого, сыграешь с ботом</div>
+      <div class="mb-3 text-sm text-blue-600">{searchSeconds} сек</div>
       <button
         onclick={cancelSearch}
         class="rounded-lg bg-white px-4 py-2 text-sm font-semibold text-stone-600 ring-1 ring-stone-200 hover:bg-stone-50"

--- a/internal/matchmaking/matchmaking.go
+++ b/internal/matchmaking/matchmaking.go
@@ -6,6 +6,7 @@ package matchmaking
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math"
 	"sync"
 	"time"
@@ -261,7 +262,9 @@ func (q *Queue) fireExpire(players []*game.Player) {
 	for _, p := range players {
 		// The player is already out of the queue; if the fallback fails there
 		// is nothing to retry — the client times out on its own.
-		_ = q.onExpire(p)
+		if err := q.onExpire(p); err != nil {
+			slog.Error("matchmaking: expire fallback failed", slog.String("playerID", p.ID), slog.Any("error", err))
+		}
 	}
 }
 

--- a/internal/service/balda_service.go
+++ b/internal/service/balda_service.go
@@ -26,10 +26,20 @@ type Balda struct {
 	s   *storage.Balda
 	lb  *leaderboard.Service
 	ach *achievements.Service
+	// botFallback starts a bot game for a player who found no human opponent.
+	botFallback func(p *game.Player) error
 }
 
 func New(lby *lobby.Lobby, mm *matchmaking.Queue, s *storage.Balda, lb *leaderboard.Service, ach *achievements.Service) *Balda {
 	return &Balda{lby: lby, mm: mm, s: s, lb: lb, ach: ach}
+}
+
+// WithBotFallback sets the function used to start a bot game when no human
+// opponent is available. It is invoked synchronously by QuickMatchJoin when
+// the matchmaking queue is empty.
+func (s *Balda) WithBotFallback(f func(p *game.Player) error) *Balda {
+	s.botFallback = f
+	return s
 }
 
 func (s *Balda) GameSummary(playerID string) *lobby.GameSummary {
@@ -134,8 +144,9 @@ func (s *Balda) RevokeAllUserTokens(ctx context.Context, uid int64) error {
 // create a game while already participating in one.
 var ErrPlayerInGame = errors.New("service: player already in a game")
 
-// QuickMatchJoin enqueues the user for quick matchmaking.
-// Returns ErrPlayerInGame if they are already in a game, or
+// QuickMatchJoin enqueues the user for quick matchmaking. When nobody else is
+// waiting, a bot game is started immediately via the bot fallback instead of
+// queuing. Returns ErrPlayerInGame if they are already in a game, or
 // matchmaking.ErrAlreadyQueued if they are already waiting.
 func (s *Balda) QuickMatchJoin(ctx context.Context, uid int64) error {
 	p, err := s.s.GetPlayerByUID(ctx, uid)
@@ -145,7 +156,11 @@ func (s *Balda) QuickMatchJoin(ctx context.Context, uid int64) error {
 	if rec := s.ActiveGameRecord(p.PlayerID.String()); rec != nil && rec.Status != lobby.GameStatusFinished {
 		return ErrPlayerInGame
 	}
-	return s.mm.Enqueue(&game.Player{ID: p.PlayerID.String(), Exp: p.Exp, Rating: p.Rating, Type: game.PlayerTypeHuman})
+	player := &game.Player{ID: p.PlayerID.String(), Exp: p.Exp, Rating: p.Rating, Type: game.PlayerTypeHuman}
+	if s.mm.Len() == 0 && s.botFallback != nil {
+		return s.botFallback(player)
+	}
+	return s.mm.Enqueue(player)
 }
 
 // QuickMatchLeave removes the user from the matchmaking queue. It is


### PR DESCRIPTION
Quick match could leave a player waiting forever: the MaxWait expire fallback ran outside the request path and its errors were silently swallowed. Now QuickMatchJoin starts the bot game synchronously when nobody else is queued, surfacing any failure to the client. The expire callback errors are logged, and the lobby sets the searching state before the join request so an early match_found event is not overwritten by the HTTP response.

Also drop the 'play with bot' hint from the search UI.