### PR TITLE
feat: friend invites via Telegram startapp deep links

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -18,3 +18,7 @@ CENTRIFUGO_SECRET=
 # Telegram bot token from @BotFather (needed for Mini App auth). Optional:
 # without it /auth/telegram answers 503 and email login keeps working.
 TELEGRAM_BOT_TOKEN=
+
+# Public Mini App link from BotFather /newapp (https://t.me/<bot>/<app>),
+# used for "invite a friend" links. Optional.
+TELEGRAM_APP_URL=

--- a/api/openapi/http-api.yaml
+++ b/api/openapi/http-api.yaml
@@ -1388,6 +1388,10 @@ components:
           description: Whether email/password registration is available
           example: false
           type: boolean
+        telegram_app_url:
+          description: Public Telegram Mini App URL used to build friend-invite links (empty when not configured)
+          example: https://t.me/balda_bot/game
+          type: string
 
     MatchmakingJoinResponse:
       type: object

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -91,6 +91,9 @@ type TelegramConfig struct {
 	// BotToken validates Telegram Mini App init data. Empty means Telegram
 	// auth is not configured; the endpoint then answers 503.
 	BotToken string
+	// AppURL is the public Mini App link (https://t.me/<bot>/<app>) used by
+	// the client to build friend-invite links. Empty hides the invite button.
+	AppURL string
 }
 
 type Config struct {
@@ -250,7 +253,7 @@ var serverCmd = &cobra.Command{
 
 		svc := service.New(lby, mm, s, lb, achSvc).WithBotFallback(startBotGame)
 
-		h := handlers.New(svc, pres, cfg.Auth.JWTSecret, cf, cfg.Centrifugo.TokenHMACSecret, cfg.Auth.EmailSignupEnabled, cfg.Telegram.BotToken)
+		h := handlers.New(svc, pres, cfg.Auth.JWTSecret, cf, cfg.Centrifugo.TokenHMACSecret, cfg.Auth.EmailSignupEnabled, cfg.Telegram.BotToken, cfg.Telegram.AppURL)
 
 		srv, err := baldaapi.NewServer(h, h,
 			baldaapi.WithPathPrefix("/balda/api/v1"),
@@ -338,6 +341,7 @@ func (c *Config) Flags(prefix string) *pflag.FlagSet {
 	f.StringVar(&c.Auth.JWTSecret, "auth.jwt_secret", "", "HMAC secret for signing JWT access tokens")
 	f.BoolVar(&c.Auth.EmailSignupEnabled, "auth.email_signup_enabled", true, "allow email/password registration (disable in prod)")
 	f.StringVar(&c.Telegram.BotToken, "telegram.bot_token", "", "telegram bot token for Mini App auth (init data validation)")
+	f.StringVar(&c.Telegram.AppURL, "telegram.app_url", "", "public Mini App URL (https://t.me/<bot>/<app>) for friend invites")
 	f.StringVar(&c.Centrifugo.APIURL, "centrifugo.api_url", "http://127.0.0.1:8000/api", "centrifugo api url")
 	f.StringVar(&c.Centrifugo.APIKey, "centrifugo.api_key", "", "centrifugo api key")
 	f.StringVar(&c.Centrifugo.TokenHMACSecret, "centrifugo.token_hmac_secret_key", "", "centrifugo token hmac secret")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,6 +54,8 @@ services:
       AUTH_EMAIL_SIGNUP_ENABLED: "false"
       # Telegram Mini App auth (optional; endpoint answers 503 when empty).
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
+      # Public Mini App link (https://t.me/<bot>/<app>) for friend invites.
+      TELEGRAM_APP_URL: ${TELEGRAM_APP_URL:-}
       PG_HOST: pg
       PG_USER: balda
       PG_DATABASE: balda

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -386,13 +386,15 @@ Centrifugo уже есть — достаточно добавить канал 
 
 ### Telegram и рост
 
-### 40. Приглашение друга в партию через startapp (P1)
-**Затрагивает:** фронт (`GameScreen`/`WaitingScreen`), Mini App
+### 40. ✅ Приглашение друга в партию через startapp (P1)
+**Затрагивает:** фронт (`WaitingScreen`/`AuthForm`), `GET /config`
 
-Кнопка «Пригласить друга» в ожидании соперника: шарится ссылка
-`t.me/<bot>/<app>?startapp=game_<id>`. Payload приезжает во фронт в
-`WebApp.initDataUnsafe.start_param` — клиент сразу джойнит указанную игру после
-авто-логина. Бэкенд бота не нужен. Самая дешёвая виральная механика.
+**Сделано:**
+- `GET /config` отдаёт `telegram_app_url` (флаг `telegram.app_url` / env `TELEGRAM_APP_URL`).
+- WaitingScreen: кнопка «Пригласить друга» → ссылка `<app_url>?startapp=game_<id>`
+  (в Telegram — нативный шаринг, в браузере — копирование в буфер).
+- Приём: после авто-логина по initData читается `initDataUnsafe.start_param`;
+  `game_<id>` → автоджойн через `joinGame`; недоступная игра → лобби + нотификация.
 
 ### 41. Бот-бэкенд: /start-ответчик и уведомления (P2)
 **Затрагивает:** `internal/server/restapi/` (webhook), `cmd/server.go`, `internal/storage/`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,6 +94,9 @@ docker compose -f docker-compose.prod.yml logs --tail 200 centrifugo
    на нашу сессию через `POST /auth/telegram` — без форм и паролей; первый
    визит создаёт пользователя (привязка по `telegram_id`).
 5. Menu button бота (Bot Settings → Menu Button) — «Играть» с тем же URL.
+6. Для приглашений друзей в партию: вписать публичную ссылку аппа в `.env`
+   (`TELEGRAM_APP_URL=https://t.me/<bot>/<app>`) и перезапустить — кнопка
+   «Пригласить друга» появится на экране ожидания соперника.
 
 Регистрация по email в проде выключена (`AUTH_EMAIL_SIGNUP_ENABLED: "false"`
 в `docker-compose.prod.yml`) — это локально-тестовый способ входа. Логин

--- a/frontend/src/components/AuthForm.svelte
+++ b/frontend/src/components/AuthForm.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { auth, signup, setTokens, getConfig, authTelegram } from '../lib/api';
+  import { auth, signup, setTokens, getConfig, authTelegram, joinGame } from '../lib/api';
   import { centrifugo } from '../lib/centrifugo';
   import { gameState } from '../stores/game.svelte';
-  import { isMiniApp, getTelegramInitData, initMiniApp } from '../lib/telegram';
+  import { isMiniApp, getTelegramInitData, initMiniApp, getStartParam } from '../lib/telegram';
   import type { AuthResponse, SignupResponse } from '../types';
 
   let isSignup = $state(false);
@@ -71,7 +71,10 @@
   // email stays for local testing). Login remains available either way.
   $effect(() => {
     getConfig()
-      .then((cfg) => (signupEnabled = cfg.email_signup_enabled))
+      .then((cfg) => {
+        signupEnabled = cfg.email_signup_enabled;
+        gameState.setTelegramAppUrl(cfg.telegram_app_url ?? '');
+      })
       .catch(() => {});
   });
 
@@ -83,10 +86,42 @@
     initMiniApp();
     authTelegram(initData)
       .then(applyAuthResponse)
+      .then(handleInvite)
       .catch((e) => {
         telegramError = e instanceof Error ? e.message : 'Ошибка входа через Telegram';
       });
   });
+
+  // handleInvite auto-joins the game from a friend-invite deep link
+  // (startapp=game_<id>). Unavailable games degrade to the lobby with a note.
+  async function handleInvite() {
+    const param = getStartParam();
+    if (!param || !param.startsWith('game_')) return;
+    const gameId = param.slice('game_'.length);
+    try {
+      const res = await joinGame(gameId);
+      if (res.game_token) {
+        centrifugo.subscribe(`game:${res.game.id}`, res.game_token);
+      }
+      gameState.startGame(res.game);
+      if (res.board && res.current_turn_uid) {
+        const players = res.game.players?.length
+          ? res.game.players.map((p) => ({ uid: p.uid, rating: p.rating, score: 0, words_count: 0, words: [] }))
+          : res.game.player_ids.map((uid) => ({ uid, rating: 0, score: 0, words_count: 0, words: [] }));
+        gameState.applyGameState({
+          type: 'game_state',
+          game_id: res.game.id,
+          board: res.board,
+          current_turn_uid: res.current_turn_uid,
+          players,
+          status: 'in_progress',
+          move_number: 0,
+        });
+      }
+    } catch {
+      gameState.showNotif('Эта игра уже недоступна', 'warn');
+    }
+  }
 
   async function handleSubmit(e: Event) {
     e.preventDefault();

--- a/frontend/src/components/WaitingScreen.svelte
+++ b/frontend/src/components/WaitingScreen.svelte
@@ -1,8 +1,31 @@
 <script lang="ts">
   import { gameState } from '../stores/game.svelte';
   import { leaveGame } from '../lib/api';
+  import { isMiniApp, shareTelegramLink } from '../lib/telegram';
 
   let error = $state('');
+  let copied = $state(false);
+
+  let inviteUrl = $derived(
+    gameState.telegramAppUrl && gameState.game?.id
+      ? `${gameState.telegramAppUrl}?startapp=game_${gameState.game.id}`
+      : ''
+  );
+
+  async function invite() {
+    if (!inviteUrl) return;
+    if (isMiniApp()) {
+      shareTelegramLink(inviteUrl);
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      copied = true;
+      setTimeout(() => (copied = false), 2000);
+    } catch {
+      error = 'Не удалось скопировать ссылку';
+    }
+  }
 
   async function cancel() {
     error = '';
@@ -27,9 +50,17 @@
   {#if error}
     <div class="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>
   {/if}
+  {#if inviteUrl}
+    <button
+      onclick={invite}
+      class="mt-6 w-full rounded-xl bg-blue-600 px-6 py-2 font-bold text-white transition hover:bg-blue-700"
+    >
+      {copied ? 'Ссылка скопирована ✓' : 'Пригласить друга'}
+    </button>
+  {/if}
   <button
     onclick={cancel}
-    class="mt-6 rounded-xl bg-stone-200 px-6 py-2 font-bold text-stone-700 transition hover:bg-stone-300"
+    class="mt-3 rounded-xl bg-stone-200 px-6 py-2 font-bold text-stone-700 transition hover:bg-stone-300"
   >
     Отменить
   </button>

--- a/frontend/src/lib/telegram.ts
+++ b/frontend/src/lib/telegram.ts
@@ -3,8 +3,10 @@
 
 interface TelegramWebApp {
   initData: string;
+  initDataUnsafe?: { start_param?: string };
   ready(): void;
   expand(): void;
+  openTelegramLink?(url: string): void;
 }
 
 interface TelegramWindow extends Window {
@@ -28,6 +30,18 @@ export function isMiniApp(): boolean {
 export function getTelegramInitData(): string | null {
   const app = webApp();
   return app && app.initData.length > 0 ? app.initData : null;
+}
+
+// getStartParam returns the startapp deep-link payload the Mini App was
+// opened with (e.g. "game_<id>" from a friend invite), or null.
+export function getStartParam(): string | null {
+  const p = webApp()?.initDataUnsafe?.start_param;
+  return p && p.length > 0 ? p : null;
+}
+
+// shareTelegramLink opens the native Telegram share dialog for the given URL.
+export function shareTelegramLink(url: string): void {
+  webApp()?.openTelegramLink?.(`https://t.me/share/url?url=${encodeURIComponent(url)}`);
 }
 
 // initMiniApp tells Telegram the app is ready and asks for the full-height

--- a/frontend/src/stores/game.svelte.ts
+++ b/frontend/src/stores/game.svelte.ts
@@ -57,6 +57,9 @@ export function createGameState() {
     // Quick match search state (matchmaking queue)
     let searching = $state<boolean>(false);
 
+    // Public Telegram Mini App URL (from /config) for friend-invite links.
+    let telegramAppUrl = $state<string>("");
+
     // End proposal
     let endProposalPending = $state<boolean>(false);
     let endProposalByMe = $state<boolean>(false);
@@ -420,6 +423,9 @@ export function createGameState() {
         get searching() {
             return searching;
         },
+        get telegramAppUrl() {
+            return telegramAppUrl;
+        },
         get endProposalPending() {
             return endProposalPending;
         },
@@ -453,6 +459,9 @@ export function createGameState() {
         clearNotif,
         setSearching(value: boolean) {
             searching = value;
+        },
+        setTelegramAppUrl(value: string) {
+            telegramAppUrl = value;
         },
         setMoveLoading(value: boolean) {
             moveLoading = value;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -227,6 +227,7 @@ export interface PlayerStats {
 
 export interface ClientConfig {
     email_signup_enabled: boolean;
+    telegram_app_url?: string;
 }
 
 export interface EvAchievementUnlocked {

--- a/internal/server/ogen/oas_json_gen.go
+++ b/internal/server/ogen/oas_json_gen.go
@@ -1067,10 +1067,17 @@ func (s *ConfigResponse) encodeFields(e *jx.Encoder) {
 			s.EmailSignupEnabled.Encode(e)
 		}
 	}
+	{
+		if s.TelegramAppURL.Set {
+			e.FieldStart("telegram_app_url")
+			s.TelegramAppURL.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfConfigResponse = [1]string{
+var jsonFieldsNameOfConfigResponse = [2]string{
 	0: "email_signup_enabled",
+	1: "telegram_app_url",
 }
 
 // Decode decodes ConfigResponse from json.
@@ -1090,6 +1097,16 @@ func (s *ConfigResponse) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"email_signup_enabled\"")
+			}
+		case "telegram_app_url":
+			if err := func() error {
+				s.TelegramAppURL.Reset()
+				if err := s.TelegramAppURL.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"telegram_app_url\"")
 			}
 		default:
 			return d.Skip()

--- a/internal/server/ogen/oas_schemas_gen.go
+++ b/internal/server/ogen/oas_schemas_gen.go
@@ -442,6 +442,8 @@ func (s *BoardCell) SetCol(val int) {
 type ConfigResponse struct {
 	// Whether email/password registration is available.
 	EmailSignupEnabled OptBool `json:"email_signup_enabled"`
+	// Public Telegram Mini App URL used to build friend-invite links (empty when not configured).
+	TelegramAppURL OptString `json:"telegram_app_url"`
 }
 
 // GetEmailSignupEnabled returns the value of EmailSignupEnabled.
@@ -449,9 +451,19 @@ func (s *ConfigResponse) GetEmailSignupEnabled() OptBool {
 	return s.EmailSignupEnabled
 }
 
+// GetTelegramAppURL returns the value of TelegramAppURL.
+func (s *ConfigResponse) GetTelegramAppURL() OptString {
+	return s.TelegramAppURL
+}
+
 // SetEmailSignupEnabled sets the value of EmailSignupEnabled.
 func (s *ConfigResponse) SetEmailSignupEnabled(val OptBool) {
 	s.EmailSignupEnabled = val
+}
+
+// SetTelegramAppURL sets the value of TelegramAppURL.
+func (s *ConfigResponse) SetTelegramAppURL(val OptString) {
+	s.TelegramAppURL = val
 }
 
 // Ref: #/components/schemas/CreateGameResponse

--- a/internal/server/restapi/handlers/config.go
+++ b/internal/server/restapi/handlers/config.go
@@ -11,5 +11,6 @@ import (
 func (h *Handlers) GetConfig(_ context.Context) (*baldaapi.ConfigResponse, error) {
 	return &baldaapi.ConfigResponse{
 		EmailSignupEnabled: baldaapi.NewOptBool(h.emailSignupEnabled),
+		TelegramAppURL:     baldaapi.NewOptString(h.telegramAppURL),
 	}, nil
 }

--- a/internal/server/restapi/handlers/handlers.go
+++ b/internal/server/restapi/handlers/handlers.go
@@ -24,10 +24,17 @@ type Handlers struct {
 	centrifugoTokenHMACSecret string
 	emailSignupEnabled        bool
 	telegramBotToken          string
+	telegramAppURL            string
 }
 
-func New(svc *service.Balda, pres *presence.Service, jwtSecret string, cf *centrifugo.Client, centrifugoTokenHMACSecret string, emailSignupEnabled bool, telegramBotToken string) *Handlers {
-	return &Handlers{svc: svc, pres: pres, jwtSecret: jwtSecret, cf: cf, centrifugoTokenHMACSecret: centrifugoTokenHMACSecret, emailSignupEnabled: emailSignupEnabled, telegramBotToken: telegramBotToken}
+func New(svc *service.Balda, pres *presence.Service, jwtSecret string, cf *centrifugo.Client, centrifugoTokenHMACSecret string, emailSignupEnabled bool, telegramBotToken, telegramAppURL string) *Handlers {
+	return &Handlers{
+		svc: svc, pres: pres, jwtSecret: jwtSecret, cf: cf,
+		centrifugoTokenHMACSecret: centrifugoTokenHMACSecret,
+		emailSignupEnabled:        emailSignupEnabled,
+		telegramBotToken:          telegramBotToken,
+		telegramAppURL:            telegramAppURL,
+	}
 }
 
 // uidFromContext returns the authenticated user's id from the JWT claims placed

--- a/tests/auth_telegram_test.go
+++ b/tests/auth_telegram_test.go
@@ -59,7 +59,7 @@ func setupTelegramHandlers(t *testing.T) (*handlers.Handlers, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, testTelegramBotToken)
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, testTelegramBotToken, "")
 	return h, core.cleanup
 }
 
@@ -115,7 +115,7 @@ func TestAuthTelegram_NotConfigured(t *testing.T) {
 	core := setupCore(ctx, t)
 	defer core.cleanup()
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, "")
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, "", "")
 
 	res, err := h.AuthTelegram(ctx, &baldaapi.TelegramAuthRequest{InitData: "whatever=1"})
 	require.NoError(t, err)

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -68,7 +68,7 @@ func setupHandlersWithCentrifugo(ctx context.Context, t *testing.T, cfAPIURL str
 	t.Helper()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient(cfAPIURL, testCentrifugoAPIKey)
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, testCentrifugoSecret, true, "")
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, testCentrifugoSecret, true, "", "")
 	return h, core.cleanup
 }
 

--- a/tests/handlers_test.go
+++ b/tests/handlers_test.go
@@ -154,7 +154,7 @@ func setupHandlers(t *testing.T) (*handlers.Handlers, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "")
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "", "")
 	return h, core.cleanup
 }
 
@@ -163,7 +163,7 @@ func TestSignupDisabled(t *testing.T) {
 	core := setupCore(ctx, t)
 	defer core.cleanup()
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, "")
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, "", "https://t.me/balda_test_bot/game")
 
 	res, err := h.Signup(ctx, &baldaapi.SignupRequest{
 		Firstname: "No",
@@ -177,10 +177,11 @@ func TestSignupDisabled(t *testing.T) {
 	require.True(t, isErr, "expected *ErrorResponse, got %T", res)
 	assert.Equal(t, http.StatusForbidden, errResp.Status.Value)
 
-	// The public config endpoint reports the same flag.
+	// The public config endpoint reports the same flags.
 	cfg, err := h.GetConfig(ctx)
 	require.NoError(t, err)
 	assert.False(t, cfg.EmailSignupEnabled.Value)
+	assert.Equal(t, "https://t.me/balda_test_bot/game", cfg.TelegramAppURL.Value)
 }
 
 func TestSignupHandler(t *testing.T) {
@@ -485,7 +486,7 @@ func setupFull(t *testing.T) (*handlers.Handlers, *lobby.Lobby, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "")
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "", "")
 	return h, core.lby, core.cleanup
 }
 

--- a/tests/leaderboard_test.go
+++ b/tests/leaderboard_test.go
@@ -23,7 +23,7 @@ func setupLeaderboard(t *testing.T) (*handlers.Handlers, *storage.Balda, *redis.
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "")
+	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "", "")
 	return h, core.s, core.rdb, core.cleanup
 }
 


### PR DESCRIPTION
- GET /config exposes telegram_app_url (flag telegram.app_url)
- WaitingScreen: invite button shares <app_url>?startapp=game_<id>
  (native Telegram share in the Mini App, clipboard copy in browser)
- after Mini App auto-login, start_param=game_<id> auto-joins the game; unavailable games degrade to the lobby with a notice

Implements item 40 from docs/IMPROVEMENTS.md