### PR TITLE
refactor: pack fat signatures into params structs (R1)

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -253,7 +253,13 @@ var serverCmd = &cobra.Command{
 
 		svc := service.New(lby, mm, s, lb, achSvc).WithBotFallback(startBotGame)
 
-		h := handlers.New(svc, pres, cfg.Auth.JWTSecret, cf, cfg.Centrifugo.TokenHMACSecret, cfg.Auth.EmailSignupEnabled, cfg.Telegram.BotToken, cfg.Telegram.AppURL)
+		h := handlers.New(svc, pres, cf, handlers.Config{
+			JWTSecret:                 cfg.Auth.JWTSecret,
+			CentrifugoTokenHMACSecret: cfg.Centrifugo.TokenHMACSecret,
+			EmailSignupEnabled:        cfg.Auth.EmailSignupEnabled,
+			TelegramBotToken:          cfg.Telegram.BotToken,
+			TelegramAppURL:            cfg.Telegram.AppURL,
+		})
 
 		srv, err := baldaapi.NewServer(h, h,
 			baldaapi.WithPathPrefix("/balda/api/v1"),

--- a/internal/server/restapi/handlers/auth.go
+++ b/internal/server/restapi/handlers/auth.go
@@ -47,7 +47,7 @@ func (h *Handlers) Auth(ctx context.Context, req *baldaapi.AuthRequest) (baldaap
 // optional active game snapshot) for an already-identified user. It is shared
 // by the email/password and Telegram auth handlers.
 func (h *Handlers) newAuthResponse(ctx context.Context, u storage.UserAuth) (*baldaapi.AuthResponse, *baldaapi.ErrorResponse) {
-	access, refresh, err := h.issueTokens(ctx, u.UID, u.PlayerID, u.Role, "", "")
+	access, refresh, err := h.issueTokens(ctx, u.UID, u.PlayerID, u.Role, tokenMeta{})
 	if err != nil {
 		slog.Error("auth: issue tokens", slog.Any("error", err))
 		return nil, &baldaapi.ErrorResponse{
@@ -94,7 +94,7 @@ func (h *Handlers) buildActiveGame(uid int64, playerID string) *baldaapi.ActiveG
 	}
 
 	gameToken, err := centrifugo.GenerateSubscriptionToken(
-		strconv.FormatInt(uid, 10), centrifugo.ChannelGame(rec.ID), h.centrifugoTokenHMACSecret, 24*time.Hour,
+		strconv.FormatInt(uid, 10), centrifugo.ChannelGame(rec.ID), h.cfg.CentrifugoTokenHMACSecret, 24*time.Hour,
 	)
 	if err != nil {
 		slog.Error("auth: generate game token for reconnect", slog.Any("error", err))

--- a/internal/server/restapi/handlers/auth_telegram.go
+++ b/internal/server/restapi/handlers/auth_telegram.go
@@ -20,7 +20,7 @@ const telegramInitDataMaxAge = 24 * time.Hour
 // init data against the bot token, then logs in the linked user or creates a
 // new one on first visit.
 func (h *Handlers) AuthTelegram(ctx context.Context, req *baldaapi.TelegramAuthRequest) (baldaapi.AuthTelegramRes, error) {
-	if h.telegramBotToken == "" {
+	if h.cfg.TelegramBotToken == "" {
 		return &baldaapi.AuthTelegramServiceUnavailable{
 			Status:  baldaapi.NewOptInt(http.StatusServiceUnavailable),
 			Message: baldaapi.NewOptString("telegram auth is not configured"),
@@ -28,7 +28,7 @@ func (h *Handlers) AuthTelegram(ctx context.Context, req *baldaapi.TelegramAuthR
 		}, nil
 	}
 
-	tgUser, err := auth.ValidateInitData(req.InitData, h.telegramBotToken, telegramInitDataMaxAge)
+	tgUser, err := auth.ValidateInitData(req.InitData, h.cfg.TelegramBotToken, telegramInitDataMaxAge)
 	if err != nil {
 		return &baldaapi.AuthTelegramUnauthorized{
 			Status:  baldaapi.NewOptInt(http.StatusUnauthorized),
@@ -49,7 +49,12 @@ func (h *Handlers) AuthTelegram(ctx context.Context, req *baldaapi.TelegramAuthR
 		if nickname == "" {
 			nickname = flname.GenNickname()
 		}
-		created, err := h.svc.CreateTelegramUser(ctx, tgUser.FirstName, tgUser.LastName, nickname, tgUser.ID)
+		created, err := h.svc.CreateTelegramUser(ctx, storage.CreateTelegramUserParams{
+			Firstname:  tgUser.FirstName,
+			Lastname:   tgUser.LastName,
+			Nickname:   nickname,
+			TelegramID: tgUser.ID,
+		})
 		if err != nil {
 			slog.Error("auth telegram: create user", slog.Any("error", err))
 			return authTelegramInternalError(), nil

--- a/internal/server/restapi/handlers/config.go
+++ b/internal/server/restapi/handlers/config.go
@@ -10,7 +10,7 @@ import (
 // client can adapt its UI before authentication.
 func (h *Handlers) GetConfig(_ context.Context) (*baldaapi.ConfigResponse, error) {
 	return &baldaapi.ConfigResponse{
-		EmailSignupEnabled: baldaapi.NewOptBool(h.emailSignupEnabled),
-		TelegramAppURL:     baldaapi.NewOptString(h.telegramAppURL),
+		EmailSignupEnabled: baldaapi.NewOptBool(h.cfg.EmailSignupEnabled),
+		TelegramAppURL:     baldaapi.NewOptString(h.cfg.TelegramAppURL),
 	}, nil
 }

--- a/internal/server/restapi/handlers/create_game.go
+++ b/internal/server/restapi/handlers/create_game.go
@@ -77,7 +77,7 @@ func (h *Handlers) CreateGame(ctx context.Context) (baldaapi.CreateGameRes, erro
 	h.publishLobbyUpdate(ctx)
 
 	gameToken, err := centrifugo.GenerateSubscriptionToken(
-		strconv.FormatInt(uid, 10), centrifugo.ChannelGame(rec.ID), h.centrifugoTokenHMACSecret, 24*time.Hour,
+		strconv.FormatInt(uid, 10), centrifugo.ChannelGame(rec.ID), h.cfg.CentrifugoTokenHMACSecret, 24*time.Hour,
 	)
 	if err != nil {
 		slog.Error("create_game: generate game token", slog.Any("error", err))

--- a/internal/server/restapi/handlers/create_game_with_bot.go
+++ b/internal/server/restapi/handlers/create_game_with_bot.go
@@ -89,7 +89,7 @@ func (h *Handlers) CreateGameWithBot(ctx context.Context) (baldaapi.CreateGameWi
 	firstPlayerID := rec.Game.CurrentPlayerID()
 
 	gameToken, err := centrifugo.GenerateSubscriptionToken(
-		strconv.FormatInt(uid, 10), centrifugo.ChannelGame(rec.ID), h.centrifugoTokenHMACSecret, 24*time.Hour,
+		strconv.FormatInt(uid, 10), centrifugo.ChannelGame(rec.ID), h.cfg.CentrifugoTokenHMACSecret, 24*time.Hour,
 	)
 	if err != nil {
 		slog.Error("create_game_with_bot: generate game token", slog.Any("error", err))

--- a/internal/server/restapi/handlers/handlers.go
+++ b/internal/server/restapi/handlers/handlers.go
@@ -13,28 +13,28 @@ import (
 	"github.com/rustwizard/balda/internal/presence"
 	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
 	"github.com/rustwizard/balda/internal/service"
+	"github.com/rustwizard/balda/internal/storage"
 )
+
+// Config holds the static configuration Handlers needs at runtime.
+type Config struct {
+	JWTSecret                 string
+	CentrifugoTokenHMACSecret string
+	EmailSignupEnabled        bool
+	TelegramBotToken          string
+	TelegramAppURL            string
+}
 
 // Handlers implements baldaapi.Handler and baldaapi.SecurityHandler.
 type Handlers struct {
-	svc                       *service.Balda
-	pres                      *presence.Service
-	jwtSecret                 string
-	cf                        *centrifugo.Client
-	centrifugoTokenHMACSecret string
-	emailSignupEnabled        bool
-	telegramBotToken          string
-	telegramAppURL            string
+	svc  *service.Balda
+	pres *presence.Service
+	cf   *centrifugo.Client
+	cfg  Config
 }
 
-func New(svc *service.Balda, pres *presence.Service, jwtSecret string, cf *centrifugo.Client, centrifugoTokenHMACSecret string, emailSignupEnabled bool, telegramBotToken, telegramAppURL string) *Handlers {
-	return &Handlers{
-		svc: svc, pres: pres, jwtSecret: jwtSecret, cf: cf,
-		centrifugoTokenHMACSecret: centrifugoTokenHMACSecret,
-		emailSignupEnabled:        emailSignupEnabled,
-		telegramBotToken:          telegramBotToken,
-		telegramAppURL:            telegramAppURL,
-	}
+func New(svc *service.Balda, pres *presence.Service, cf *centrifugo.Client, cfg Config) *Handlers {
+	return &Handlers{svc: svc, pres: pres, cf: cf, cfg: cfg}
 }
 
 // uidFromContext returns the authenticated user's id from the JWT claims placed
@@ -47,10 +47,16 @@ func uidFromContext(ctx context.Context) (uid int64, ok bool) {
 	return c.UID, true
 }
 
+// tokenMeta carries optional client metadata attached to a refresh token.
+type tokenMeta struct {
+	UserAgent string
+	IPAddr    string
+}
+
 // issueTokens mints an access token and a rotated refresh token for the user,
 // persisting the HMAC hash of the refresh token. Returns the raw tokens.
-func (h *Handlers) issueTokens(ctx context.Context, uid int64, pid uuid.UUID, role, userAgent, ipAddr string) (access, refresh string, err error) {
-	access, err = auth.GenerateAccessToken(uid, pid, role, h.jwtSecret)
+func (h *Handlers) issueTokens(ctx context.Context, uid int64, pid uuid.UUID, role string, meta tokenMeta) (access, refresh string, err error) {
+	access, err = auth.GenerateAccessToken(uid, pid, role, h.cfg.JWTSecret)
 	if err != nil {
 		return "", "", fmt.Errorf("issue tokens: access: %w", err)
 	}
@@ -58,8 +64,14 @@ func (h *Handlers) issueTokens(ctx context.Context, uid int64, pid uuid.UUID, ro
 	if err != nil {
 		return "", "", fmt.Errorf("issue tokens: refresh: %w", err)
 	}
-	hash := auth.HashRefreshToken(h.jwtSecret, refresh)
-	if err := h.svc.SaveRefreshToken(ctx, uid, hash, time.Now().Add(auth.RefreshTokenTTL), userAgent, ipAddr); err != nil {
+	hash := auth.HashRefreshToken(h.cfg.JWTSecret, refresh)
+	if err := h.svc.SaveRefreshToken(ctx, storage.RefreshToken{
+		UserID:    uid,
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(auth.RefreshTokenTTL),
+		UserAgent: meta.UserAgent,
+		IPAddr:    meta.IPAddr,
+	}); err != nil {
 		return "", "", fmt.Errorf("issue tokens: save: %w", err)
 	}
 	return access, refresh, nil
@@ -69,12 +81,12 @@ func (h *Handlers) issueTokens(ctx context.Context, uid int64, pid uuid.UUID, ro
 func (h *Handlers) generateCentrifugoTokens(uid int64) (cfToken, lobbyToken string, err error) {
 	sub := strconv.FormatInt(uid, 10)
 	ttl := 24 * time.Hour
-	cfToken, err = centrifugo.GenerateConnectionToken(sub, h.centrifugoTokenHMACSecret, ttl)
+	cfToken, err = centrifugo.GenerateConnectionToken(sub, h.cfg.CentrifugoTokenHMACSecret, ttl)
 	if err != nil {
 		slog.Error("generate centrifugo connection token", slog.Any("error", err))
 		return
 	}
-	lobbyToken, err = centrifugo.GenerateSubscriptionToken(sub, centrifugo.ChannelLobby, h.centrifugoTokenHMACSecret, ttl)
+	lobbyToken, err = centrifugo.GenerateSubscriptionToken(sub, centrifugo.ChannelLobby, h.cfg.CentrifugoTokenHMACSecret, ttl)
 	if err != nil {
 		slog.Error("generate centrifugo lobby token", slog.Any("error", err))
 	}
@@ -113,7 +125,7 @@ func (h *Handlers) publishLobbyUpdate(ctx context.Context) {
 // access token and injects the resulting claims into the request context.
 // A returned error is rendered by ogen as 401 Unauthorized.
 func (h *Handlers) HandleBearerAuth(ctx context.Context, _ baldaapi.OperationName, t baldaapi.BearerAuth) (context.Context, error) {
-	claims, err := auth.ParseAccessToken(t.Token, h.jwtSecret)
+	claims, err := auth.ParseAccessToken(t.Token, h.cfg.JWTSecret)
 	if err != nil {
 		return ctx, err
 	}

--- a/internal/server/restapi/handlers/join_game.go
+++ b/internal/server/restapi/handlers/join_game.go
@@ -106,7 +106,7 @@ func (h *Handlers) JoinGame(ctx context.Context, params baldaapi.JoinGameParams)
 	}
 
 	gameToken, err := centrifugo.GenerateSubscriptionToken(
-		strconv.FormatInt(uid, 10), centrifugo.ChannelGame(rec.ID), h.centrifugoTokenHMACSecret, 24*time.Hour,
+		strconv.FormatInt(uid, 10), centrifugo.ChannelGame(rec.ID), h.cfg.CentrifugoTokenHMACSecret, 24*time.Hour,
 	)
 	if err != nil {
 		slog.Error("join_game: generate game token", slog.Any("error", err))

--- a/internal/server/restapi/handlers/logout.go
+++ b/internal/server/restapi/handlers/logout.go
@@ -15,7 +15,7 @@ import (
 // blacklist for immediate access-token revocation is a future enhancement.
 func (h *Handlers) Logout(ctx context.Context, req baldaapi.OptLogoutRequest) (baldaapi.LogoutRes, error) {
 	if req.Set && req.Value.RefreshToken.Set && req.Value.RefreshToken.Value != "" {
-		hash := auth.HashRefreshToken(h.jwtSecret, req.Value.RefreshToken.Value)
+		hash := auth.HashRefreshToken(h.cfg.JWTSecret, req.Value.RefreshToken.Value)
 		if err := h.svc.RevokeRefreshToken(ctx, hash); err != nil {
 			slog.Error("logout: revoke refresh token", slog.Any("error", err))
 		}

--- a/internal/server/restapi/handlers/refresh.go
+++ b/internal/server/restapi/handlers/refresh.go
@@ -15,7 +15,7 @@ import (
 // RefreshToken implements baldaapi.Handler. It validates the presented refresh
 // token, rotates it (revoking the old one), and returns a fresh token pair.
 func (h *Handlers) RefreshToken(ctx context.Context, req *baldaapi.RefreshRequest) (baldaapi.RefreshTokenRes, error) {
-	hash := auth.HashRefreshToken(h.jwtSecret, req.RefreshToken)
+	hash := auth.HashRefreshToken(h.cfg.JWTSecret, req.RefreshToken)
 
 	rt, err := h.svc.GetRefreshToken(ctx, hash)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -62,7 +62,7 @@ func (h *Handlers) RefreshToken(ctx context.Context, req *baldaapi.RefreshReques
 		}, nil
 	}
 
-	access, refresh, err := h.issueTokens(ctx, rt.UserID, u.PlayerID, u.Role, rt.UserAgent, rt.IPAddr)
+	access, refresh, err := h.issueTokens(ctx, rt.UserID, u.PlayerID, u.Role, tokenMeta{UserAgent: rt.UserAgent, IPAddr: rt.IPAddr})
 	if err != nil {
 		slog.Error("refresh: issue tokens", slog.Any("error", err))
 		return &baldaapi.ErrorResponse{

--- a/internal/server/restapi/handlers/signup.go
+++ b/internal/server/restapi/handlers/signup.go
@@ -8,11 +8,12 @@ import (
 	"github.com/rustwizard/balda/internal/auth"
 	"github.com/rustwizard/balda/internal/flname"
 	baldaapi "github.com/rustwizard/balda/internal/server/ogen"
+	"github.com/rustwizard/balda/internal/storage"
 )
 
 // Signup implements baldaapi.Handler.
 func (h *Handlers) Signup(ctx context.Context, req *baldaapi.SignupRequest) (baldaapi.SignupRes, error) {
-	if !h.emailSignupEnabled {
+	if !h.cfg.EmailSignupEnabled {
 		return &baldaapi.ErrorResponse{
 			Message: baldaapi.NewOptString("registration is disabled"),
 			Status:  baldaapi.NewOptInt(http.StatusForbidden),
@@ -20,7 +21,13 @@ func (h *Handlers) Signup(ctx context.Context, req *baldaapi.SignupRequest) (bal
 		}, nil
 	}
 
-	created, err := h.svc.CreateUser(ctx, req.Firstname, req.Lastname, req.Email, req.Password, flname.GenNickname())
+	created, err := h.svc.CreateUser(ctx, storage.CreateUserParams{
+		Firstname: req.Firstname,
+		Lastname:  req.Lastname,
+		Email:     req.Email,
+		Password:  req.Password,
+		Nickname:  flname.GenNickname(),
+	})
 	if err != nil {
 		slog.Error("signup: create user", slog.Any("error", err))
 		return &baldaapi.ErrorResponse{
@@ -30,7 +37,7 @@ func (h *Handlers) Signup(ctx context.Context, req *baldaapi.SignupRequest) (bal
 		}, nil
 	}
 
-	access, refresh, err := h.issueTokens(ctx, created.UID, created.PlayerID, created.Role, "", "")
+	access, refresh, err := h.issueTokens(ctx, created.UID, created.PlayerID, created.Role, tokenMeta{})
 	if err != nil {
 		slog.Error("signup: issue tokens", slog.Any("error", err))
 		return &baldaapi.ErrorResponse{

--- a/internal/service/balda_service.go
+++ b/internal/service/balda_service.go
@@ -77,8 +77,9 @@ func (s *Balda) AuthUser(ctx context.Context, email, password string) (storage.U
 }
 
 // CreateUser registers a new user with their player profile in one transaction.
-func (s *Balda) CreateUser(ctx context.Context, firstname, lastname, email, password, nickname string) (storage.UserCreated, error) {
-	return s.s.CreateUser(ctx, firstname, lastname, email, password, nickname)
+// CreateUser creates a new email/password user with their player state.
+func (s *Balda) CreateUser(ctx context.Context, p storage.CreateUserParams) (storage.UserCreated, error) {
+	return s.s.CreateUser(ctx, p)
 }
 
 // GetPlayerState returns the profile fields for the given player UUID.
@@ -116,13 +117,13 @@ func (s *Balda) GetUserByTelegramID(ctx context.Context, telegramID int64) (stor
 }
 
 // CreateTelegramUser creates a new user registered via Telegram Mini App auth.
-func (s *Balda) CreateTelegramUser(ctx context.Context, firstname, lastname, nickname string, telegramID int64) (storage.UserCreated, error) {
-	return s.s.CreateTelegramUser(ctx, firstname, lastname, nickname, telegramID)
+func (s *Balda) CreateTelegramUser(ctx context.Context, p storage.CreateTelegramUserParams) (storage.UserCreated, error) {
+	return s.s.CreateTelegramUser(ctx, p)
 }
 
 // SaveRefreshToken persists the HMAC hash of a refresh token for the user.
-func (s *Balda) SaveRefreshToken(ctx context.Context, uid int64, tokenHash string, expiresAt time.Time, userAgent, ipAddr string) error {
-	return s.s.SaveRefreshToken(ctx, uid, tokenHash, expiresAt, userAgent, ipAddr)
+func (s *Balda) SaveRefreshToken(ctx context.Context, rt storage.RefreshToken) error {
+	return s.s.SaveRefreshToken(ctx, rt)
 }
 
 // GetRefreshToken fetches a refresh token row by its hash.

--- a/internal/storage/token.go
+++ b/internal/storage/token.go
@@ -21,15 +21,16 @@ type RefreshToken struct {
 }
 
 // SaveRefreshToken stores an HMAC-SHA256-hashed refresh token for the user.
-// Empty userAgent / ipAddr are stored as NULL.
-func (b *Balda) SaveRefreshToken(ctx context.Context, uid int64, tokenHash string, expiresAt time.Time, userAgent, ipAddr string) error {
+// TokenID, IssuedAt and Revoked are not used on insert (defaults apply).
+// Empty UserAgent / IPAddr are stored as NULL.
+func (b *Balda) SaveRefreshToken(ctx context.Context, rt RefreshToken) error {
 	ctx, cancel := context.WithTimeout(ctx, b.t)
 	defer cancel()
 
 	_, err := b.db.Exec(ctx,
 		`INSERT INTO refresh_tokens(user_id, token_hash, expires_at, user_agent, ip_addr)
 		 VALUES($1, $2, $3, NULLIF($4, ''), NULLIF($5, '')::inet)`,
-		uid, tokenHash, expiresAt, userAgent, ipAddr,
+		rt.UserID, rt.TokenHash, rt.ExpiresAt, rt.UserAgent, rt.IPAddr,
 	)
 	if err != nil {
 		return fmt.Errorf("save refresh token: %w", err)

--- a/internal/storage/user.go
+++ b/internal/storage/user.go
@@ -108,10 +108,18 @@ func (b *Balda) GetUserByTelegramID(ctx context.Context, telegramID int64) (User
 	return u, nil
 }
 
+// CreateTelegramUserParams holds the fields for registering a Telegram user.
+type CreateTelegramUserParams struct {
+	Firstname  string
+	Lastname   string
+	Nickname   string
+	TelegramID int64
+}
+
 // CreateTelegramUser inserts a new user registered via Telegram Mini App auth
 // together with their player_state in a single transaction. The user has no
 // email and no usable password: password login is unavailable for them.
-func (b *Balda) CreateTelegramUser(ctx context.Context, firstname, lastname, nickname string, telegramID int64) (UserCreated, error) {
+func (b *Balda) CreateTelegramUser(ctx context.Context, p CreateTelegramUserParams) (UserCreated, error) {
 	ctx, cancel := context.WithTimeout(ctx, b.t)
 	defer cancel()
 
@@ -132,7 +140,7 @@ func (b *Balda) CreateTelegramUser(ctx context.Context, firstname, lastname, nic
 	err = tx.QueryRow(ctx,
 		`INSERT INTO users(first_name, last_name, email, hash_password, telegram_id, confirmed)
 		 VALUES($1, $2, NULL, $3, $4, true) RETURNING user_id, role`,
-		firstname, lastname, string(hash), telegramID,
+		p.Firstname, p.Lastname, string(hash), p.TelegramID,
 	).Scan(&created.UID, &created.Role)
 	if err != nil {
 		return UserCreated{}, fmt.Errorf("create telegram user: insert users: %w", err)
@@ -141,7 +149,7 @@ func (b *Balda) CreateTelegramUser(ctx context.Context, firstname, lastname, nic
 	err = tx.QueryRow(ctx,
 		`INSERT INTO player_state(user_id, nickname, exp, rating, flags, lives, total_games, consecutive_wins)
 		 VALUES($1, $2, $3, $4, $5, $6, $7, $8) RETURNING player_id`,
-		created.UID, nickname, 0, DefaultRating, 0, 5, 0, 0,
+		created.UID, p.Nickname, 0, DefaultRating, 0, 5, 0, 0,
 	).Scan(&created.PlayerID)
 	created.Rating = DefaultRating
 	if err != nil {
@@ -154,8 +162,17 @@ func (b *Balda) CreateTelegramUser(ctx context.Context, firstname, lastname, nic
 	return created, nil
 }
 
+// CreateUserParams holds the fields for registering an email/password user.
+type CreateUserParams struct {
+	Firstname string
+	Lastname  string
+	Email     string
+	Password  string
+	Nickname  string
+}
+
 // CreateUser inserts a new user and their player_state in a single transaction.
-func (b *Balda) CreateUser(ctx context.Context, firstname, lastname, email, password, nickname string) (UserCreated, error) {
+func (b *Balda) CreateUser(ctx context.Context, p CreateUserParams) (UserCreated, error) {
 	ctx, cancel := context.WithTimeout(ctx, b.t)
 	defer cancel()
 
@@ -165,7 +182,7 @@ func (b *Balda) CreateUser(ctx context.Context, firstname, lastname, email, pass
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(p.Password), bcryptCost)
 	if err != nil {
 		return UserCreated{}, fmt.Errorf("create user: hash password: %w", err)
 	}
@@ -174,7 +191,7 @@ func (b *Balda) CreateUser(ctx context.Context, firstname, lastname, email, pass
 	err = tx.QueryRow(ctx,
 		`INSERT INTO users(first_name, last_name, email, hash_password)
 		 VALUES($1, $2, $3, $4) RETURNING user_id, role`,
-		firstname, lastname, email, string(hash),
+		p.Firstname, p.Lastname, p.Email, string(hash),
 	).Scan(&created.UID, &created.Role)
 	if err != nil {
 		return UserCreated{}, fmt.Errorf("create user: insert users: %w", err)
@@ -183,7 +200,7 @@ func (b *Balda) CreateUser(ctx context.Context, firstname, lastname, email, pass
 	err = tx.QueryRow(ctx,
 		`INSERT INTO player_state(user_id, nickname, exp, rating, flags, lives, total_games, consecutive_wins)
 		 VALUES($1, $2, $3, $4, $5, $6, $7, $8) RETURNING player_id`,
-		created.UID, nickname, 0, DefaultRating, 0, 5, 0, 0,
+		created.UID, p.Nickname, 0, DefaultRating, 0, 5, 0, 0,
 	).Scan(&created.PlayerID)
 	created.Rating = DefaultRating
 	if err != nil {

--- a/tests/auth_telegram_test.go
+++ b/tests/auth_telegram_test.go
@@ -59,7 +59,7 @@ func setupTelegramHandlers(t *testing.T) (*handlers.Handlers, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, testTelegramBotToken, "")
+	h := handlers.New(core.svc, core.pres, cf, handlers.Config{JWTSecret: testJWTSecret, CentrifugoTokenHMACSecret: "test-secret", TelegramBotToken: testTelegramBotToken})
 	return h, core.cleanup
 }
 
@@ -115,7 +115,7 @@ func TestAuthTelegram_NotConfigured(t *testing.T) {
 	core := setupCore(ctx, t)
 	defer core.cleanup()
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, "", "")
+	h := handlers.New(core.svc, core.pres, cf, handlers.Config{JWTSecret: testJWTSecret, CentrifugoTokenHMACSecret: "test-secret"})
 
 	res, err := h.AuthTelegram(ctx, &baldaapi.TelegramAuthRequest{InitData: "whatever=1"})
 	require.NoError(t, err)

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -68,7 +68,7 @@ func setupHandlersWithCentrifugo(ctx context.Context, t *testing.T, cfAPIURL str
 	t.Helper()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient(cfAPIURL, testCentrifugoAPIKey)
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, testCentrifugoSecret, true, "", "")
+	h := handlers.New(core.svc, core.pres, cf, handlers.Config{JWTSecret: testJWTSecret, CentrifugoTokenHMACSecret: testCentrifugoSecret, EmailSignupEnabled: true})
 	return h, core.cleanup
 }
 

--- a/tests/handlers_test.go
+++ b/tests/handlers_test.go
@@ -154,7 +154,7 @@ func setupHandlers(t *testing.T) (*handlers.Handlers, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "", "")
+	h := handlers.New(core.svc, core.pres, cf, handlers.Config{JWTSecret: testJWTSecret, CentrifugoTokenHMACSecret: "test-secret", EmailSignupEnabled: true})
 	return h, core.cleanup
 }
 
@@ -163,7 +163,7 @@ func TestSignupDisabled(t *testing.T) {
 	core := setupCore(ctx, t)
 	defer core.cleanup()
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", false, "", "https://t.me/balda_test_bot/game")
+	h := handlers.New(core.svc, core.pres, cf, handlers.Config{JWTSecret: testJWTSecret, CentrifugoTokenHMACSecret: "test-secret", TelegramAppURL: "https://t.me/balda_test_bot/game"})
 
 	res, err := h.Signup(ctx, &baldaapi.SignupRequest{
 		Firstname: "No",
@@ -486,7 +486,7 @@ func setupFull(t *testing.T) (*handlers.Handlers, *lobby.Lobby, func()) {
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "", "")
+	h := handlers.New(core.svc, core.pres, cf, handlers.Config{JWTSecret: testJWTSecret, CentrifugoTokenHMACSecret: "test-secret", EmailSignupEnabled: true})
 	return h, core.lby, core.cleanup
 }
 

--- a/tests/leaderboard_test.go
+++ b/tests/leaderboard_test.go
@@ -23,7 +23,7 @@ func setupLeaderboard(t *testing.T) (*handlers.Handlers, *storage.Balda, *redis.
 	ctx := context.Background()
 	core := setupCore(ctx, t)
 	cf := centrifugo.NewClient("http://localhost:8000/api", "test-key")
-	h := handlers.New(core.svc, core.pres, testJWTSecret, cf, "test-secret", true, "", "")
+	h := handlers.New(core.svc, core.pres, cf, handlers.Config{JWTSecret: testJWTSecret, CentrifugoTokenHMACSecret: "test-secret", EmailSignupEnabled: true})
 	return h, core.s, core.rdb, core.cleanup
 }
 

--- a/tests/token_storage_test.go
+++ b/tests/token_storage_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/rustwizard/balda/internal/auth"
+	"github.com/rustwizard/balda/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +31,9 @@ func TestRefreshTokenStorage(t *testing.T) {
 	hash := auth.HashRefreshToken(secret, raw)
 	exp := time.Now().Add(auth.RefreshTokenTTL)
 
-	require.NoError(t, s.SaveRefreshToken(ctx, uid, hash, exp, "test-agent", "192.168.1.1"))
+	require.NoError(t, s.SaveRefreshToken(ctx, storage.RefreshToken{
+		UserID: uid, TokenHash: hash, ExpiresAt: exp, UserAgent: "test-agent", IPAddr: "192.168.1.1",
+	}))
 
 	t.Run("get returns the saved token", func(t *testing.T) {
 		rt, err := s.GetRefreshToken(ctx, hash)
@@ -59,7 +62,9 @@ func TestRefreshTokenStorage(t *testing.T) {
 		raw2, err := auth.GenerateRefreshToken()
 		require.NoError(t, err)
 		hash2 := auth.HashRefreshToken(secret, raw2)
-		require.NoError(t, s.SaveRefreshToken(ctx, uid, hash2, exp, "", ""))
+		require.NoError(t, s.SaveRefreshToken(ctx, storage.RefreshToken{
+			UserID: uid, TokenHash: hash2, ExpiresAt: exp,
+		}))
 
 		require.NoError(t, s.RevokeAllUserTokens(ctx, uid))
 		rt, err := s.GetRefreshToken(ctx, hash2)


### PR DESCRIPTION
- handlers.New: 8 params -> handlers.Config
- storage.CreateUser/CreateTelegramUser: params structs
- storage.SaveRefreshToken: reuses the existing RefreshToken type
- handlers.issueTokens: userAgent/ipAddr packed into tokenMeta

No behavior changes; full test suite and lint green.